### PR TITLE
[v2.1.2] Improve React connection foundation and shell UX

### DIFF
--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -1333,6 +1333,28 @@ Output JSON:
 }
 ```
 
+### GET `/runtime/status`
+What it does: returns lightweight runtime connectivity state for the frontend shell.
+
+Auth: required.
+
+Output JSON:
+```json
+{
+  "status": "success",
+  "runtime_status": {
+    "backend_reachable": true,
+    "ssh_connected": false,
+    "websocket": {
+      "active_connections": 1,
+      "cleanup_thread_running": true,
+      "runtime": {}
+    },
+    "timestamp": "2026-03-14T12:00:00"
+  }
+}
+```
+
 ### GET `/websocket/status`
 What it does: reports websocket connection count and per-connection timing info.
 
@@ -1466,7 +1488,7 @@ This document covers all `/api/*` routes currently implemented in backend Python
 - 10 transfer endpoints
 - 29 webhook-related endpoints (receivers, management, rename, settings, Discord)
 - 7 backup endpoints
-- 6 debug endpoints
+- 7 debug endpoints
 - 2 simulation endpoints
 
-Total covered: 75 method+path API endpoints.
+Total covered: 76 method+path API endpoints.

--- a/frontend/src/components/dashboard/connection-status-bar.tsx
+++ b/frontend/src/components/dashboard/connection-status-bar.tsx
@@ -10,10 +10,13 @@ import {
 import type { ConnectionState } from '@/stores/runtime';
 
 interface ConnectionStatusBarProps {
+    backendReachable: boolean;
     connectionState: ConnectionState;
+    realtimeRequested: boolean;
     statusMessage: string;
     timeRemainingMinutes?: number;
     activeSocketConnections?: number;
+    onEnableRealtime: () => void;
     onReconnect: () => void;
     onDisconnect?: () => void;
     onExtendSession?: () => void;
@@ -23,10 +26,13 @@ interface ConnectionStatusBarProps {
 }
 
 export function ConnectionStatusBar({
+    backendReachable,
     connectionState,
+    realtimeRequested,
     statusMessage,
     timeRemainingMinutes = 0,
     activeSocketConnections,
+    onEnableRealtime,
     onReconnect,
     onDisconnect,
     onExtendSession,
@@ -34,10 +40,12 @@ export function ConnectionStatusBar({
     isReconnecting = false,
     onCollapseAll,
 }: ConnectionStatusBarProps) {
+    const idle = connectionState === 'idle';
     const connected = connectionState === 'connected';
     const connecting = connectionState === 'connecting';
     const autoDisconnected = connectionState === 'auto-disconnected';
     const configChanged = connectionState === 'config-changed';
+    const disconnected = connectionState === 'disconnected';
 
     return (
         <div className="rounded-xl border border-fuchsia-500/20 bg-gradient-to-r from-neutral-900 via-neutral-900 to-neutral-900/70 p-4 shadow-[0_14px_35px_-30px_rgba(217,70,239,0.85)] flex items-center justify-between">
@@ -50,7 +58,9 @@ export function ConnectionStatusBar({
                         connecting && "bg-blue-500 animate-pulse",
                         autoDisconnected && "bg-amber-500",
                         configChanged && "bg-yellow-500",
-                        !connected && !connecting && !autoDisconnected && !configChanged && "bg-red-500"
+                        disconnected && "bg-red-500",
+                        idle && backendReachable && "bg-neutral-500",
+                        !backendReachable && "bg-red-500"
                     )}
                 />
                 <div className="text-sm text-neutral-300 space-y-0.5">
@@ -58,7 +68,7 @@ export function ConnectionStatusBar({
                     <div className="text-xs text-neutral-500 flex items-center gap-3">
                         <span className="inline-flex items-center gap-1">
                             <IconClock className="h-3.5 w-3.5" />
-                            {connected ? `${timeRemainingMinutes} min left` : 'Realtime offline'}
+                            {connected ? `${timeRemainingMinutes} min left` : realtimeRequested ? 'Realtime paused' : 'Polling only'}
                         </span>
                         {typeof activeSocketConnections === 'number' && (
                             <button
@@ -97,16 +107,28 @@ export function ConnectionStatusBar({
                         Extend
                     </Button>
                 )}
-                <Button
-                    variant="default"
-                    size="sm"
-                    className="h-8 gap-1.5 shadow-sm shadow-fuchsia-950/40"
-                    onClick={onReconnect}
-                    disabled={isReconnecting}
-                >
-                    <IconRefresh className={cn("h-4 w-4", isReconnecting && "animate-spin")} />
-                    {configChanged ? 'Apply Settings' : 'Reconnect'}
-                </Button>
+                {!realtimeRequested ? (
+                    <Button
+                        variant="default"
+                        size="sm"
+                        className="h-8 gap-1.5 shadow-sm shadow-fuchsia-950/40"
+                        onClick={onEnableRealtime}
+                    >
+                        <IconBolt className="h-4 w-4" />
+                        Enable Realtime
+                    </Button>
+                ) : (
+                    <Button
+                        variant="default"
+                        size="sm"
+                        className="h-8 gap-1.5 shadow-sm shadow-fuchsia-950/40"
+                        onClick={onReconnect}
+                        disabled={isReconnecting}
+                    >
+                        <IconRefresh className={cn("h-4 w-4", isReconnecting && "animate-spin")} />
+                        {configChanged ? 'Apply Settings' : connected ? 'Refresh' : 'Reconnect'}
+                    </Button>
+                )}
                 {onDisconnect && connected && (
                     <Button
                         variant="outline"
@@ -115,7 +137,7 @@ export function ConnectionStatusBar({
                         onClick={onDisconnect}
                     >
                         <IconPlugConnectedX className="h-4 w-4" />
-                        Disconnect
+                        Disable Realtime
                     </Button>
                 )}
             </div>

--- a/frontend/src/components/layout/app-layout.tsx
+++ b/frontend/src/components/layout/app-layout.tsx
@@ -2,15 +2,16 @@ import { useState, type ComponentType, type ReactNode } from 'react';
 import { Link, useLocation } from '@tanstack/react-router';
 import { useAuthStore } from '@/stores/auth';
 import { useLogout } from '@/hooks/useAuth';
-import { useSSHStatus } from '@/hooks/useConfig';
+import { useRuntimeStatus } from '@/hooks/useConfig';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { useRuntimeStore } from '@/stores/runtime';
-import { connectSocket } from '@/services/socket';
 import { BackendUnavailableOverlay } from '@/components/layout/backend-unavailable-overlay';
 import {
+  IconBolt,
+  IconPlugConnected,
   IconLayoutDashboard,
   IconMovie,
   IconDeviceTv,
@@ -66,14 +67,32 @@ export function AppLayout({ children }: AppLayoutProps) {
   const location = useLocation();
   const [mediaExpandedManual, setMediaExpandedManual] = useState(true);
   const { user } = useAuthStore();
-  const socketError = useRuntimeStore((state) => state.socketError);
-  const sshStatusQuery = useSSHStatus();
+  const backendReachable = useRuntimeStore((state) => state.backendReachable);
+  const backendError = useRuntimeStore((state) => state.backendError);
+  const realtimeRequested = useRuntimeStore((state) => state.realtimeRequested);
+  const socketConnected = useRuntimeStore((state) => state.socketConnected);
+  const liveActivityMessage = useRuntimeStore((state) => state.liveActivityMessage);
+  const liveActivityType = useRuntimeStore((state) => state.liveActivityType);
+  const liveActivityAt = useRuntimeStore((state) => state.liveActivityAt);
+  const runtimeStatusQuery = useRuntimeStatus();
   const logoutMutation = useLogout();
   const mediaExpanded = location.pathname.startsWith('/media/') || mediaExpandedManual;
-  const backendUnavailable = sshStatusQuery.isError;
+  const backendUnavailable = runtimeStatusQuery.isError || !backendReachable;
   const backendErrorMessage =
-    (sshStatusQuery.error instanceof Error ? sshStatusQuery.error.message : null) ??
-    socketError;
+    (runtimeStatusQuery.error instanceof Error ? runtimeStatusQuery.error.message : null) ??
+    backendError;
+
+  const realtimeTitle = (() => {
+    if (socketConnected) {
+      return liveActivityMessage ? `Realtime active: ${liveActivityMessage}` : 'Realtime active across all pages';
+    }
+    if (realtimeRequested) return 'Realtime is connecting';
+    return 'Realtime is off. Enable it from the dashboard.';
+  })();
+
+  const liveActivityAgeLabel = liveActivityAt
+    ? new Date(liveActivityAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : null;
 
   const handleLogout = () => {
     logoutMutation.mutate();
@@ -82,8 +101,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   const retryBackendConnection = async () => {
     try {
       setRetryingBackend(true);
-      connectSocket();
-      await sshStatusQuery.refetch();
+      await runtimeStatusQuery.refetch();
     } finally {
       setRetryingBackend(false);
     }
@@ -136,18 +154,18 @@ export function AppLayout({ children }: AppLayoutProps) {
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(217,70,239,0.2),transparent_52%)]" />
         <div className="relative flex flex-col h-full">
           {/* Logo Section */}
-          <div className="p-3 border-b border-sidebar-border/70">
-            <div className="flex items-center justify-between gap-2">
+          <div className="flex h-14 items-center border-b border-sidebar-border/70 px-3">
+            <div className="flex w-full items-center justify-between gap-2">
               <Link
                 to="/dashboard"
-                className="flex min-w-0 items-center gap-3 rounded-xl px-2 py-2 transition-colors hover:bg-sidebar-accent/45"
+                className="flex min-w-0 items-center gap-3 rounded-xl py-1.5 transition-colors hover:bg-sidebar-accent/45"
               >
                 <img
                   src={LOGO_URL}
                   alt="DragonCP Logo"
-                  className="h-10 w-10 object-contain shrink-0"
+                  className="h-9 w-9 object-contain shrink-0"
                 />
-                <span className="truncate text-lg font-bold tracking-[0.16em] text-transparent bg-clip-text bg-gradient-to-r from-[#6a00fd] via-[#b200ff] to-[#fe00fc]">
+                <span className="truncate text-[1.05rem] font-bold tracking-[0.16em] text-transparent bg-clip-text bg-gradient-to-r from-[#6a00fd] via-[#b200ff] to-[#fe00fc]">
                   DRAGON-CP
                 </span>
               </Link>
@@ -246,6 +264,27 @@ export function AppLayout({ children }: AppLayoutProps) {
             {/* Breadcrumb or page title can go here */}
           </div>
           <div className="flex items-center gap-3">
+            <div
+              className={cn(
+                'flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs transition-colors',
+                socketConnected
+                  ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+                  : realtimeRequested
+                    ? 'border-blue-500/35 bg-blue-500/10 text-blue-200'
+                    : 'border-border/70 bg-card/80 text-muted-foreground'
+              )}
+              title={realtimeTitle}
+            >
+              {socketConnected ? <IconPlugConnected className="h-3.5 w-3.5" /> : <IconBolt className="h-3.5 w-3.5" />}
+              <span>{socketConnected ? 'Realtime On' : realtimeRequested ? 'Realtime Starting' : 'Polling Mode'}</span>
+              {socketConnected && liveActivityMessage && (
+                <span className="max-w-56 truncate text-[11px] text-emerald-100/80">
+                  {liveActivityType ? `${liveActivityType}: ` : ''}
+                  {liveActivityMessage}
+                  {liveActivityAgeLabel ? ` - ${liveActivityAgeLabel}` : ''}
+                </span>
+              )}
+            </div>
             <Badge variant="outline" className="text-xs text-muted-foreground border-border/70">
               {APP_VERSION}
             </Badge>
@@ -287,6 +326,19 @@ export function AppLayout({ children }: AppLayoutProps) {
             </div>
           </div>
           <div className="flex items-center gap-2">
+            <div
+              className={cn(
+                'rounded-full border px-2.5 py-1 text-[11px]',
+                socketConnected
+                  ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200'
+                  : realtimeRequested
+                    ? 'border-blue-500/35 bg-blue-500/10 text-blue-200'
+                    : 'border-sidebar-border/70 bg-sidebar/70 text-sidebar-foreground/60'
+              )}
+              title={realtimeTitle}
+            >
+              {socketConnected ? 'Live' : realtimeRequested ? 'Starting' : 'Polling'}
+            </div>
             <Badge variant="outline" className="text-xs text-sidebar-foreground/60 border-sidebar-border/70">
               {APP_VERSION}
             </Badge>
@@ -314,7 +366,7 @@ export function AppLayout({ children }: AppLayoutProps) {
       <BackendUnavailableOverlay
         isVisible={backendUnavailable}
         errorMessage={backendErrorMessage}
-        isRetrying={retryingBackend || sshStatusQuery.isFetching}
+        isRetrying={retryingBackend || runtimeStatusQuery.isFetching}
         onRetry={retryBackendConnection}
       />
     </div>

--- a/frontend/src/components/pages/dashboard.tsx
+++ b/frontend/src/components/pages/dashboard.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@tanstack/react-router';
 import { toast } from 'sonner';
-import { useRuntimeConnection } from '@/hooks/useRuntime';
-import { useSSHAutoConnect, useSSHDisconnect, useWebSocketStatus } from '@/hooks/useConfig';
+import { useRuntimeController } from '@/hooks/useRuntime';
+import { useWebSocketStatus } from '@/hooks/useConfig';
 import { useActiveTransfers, useCancelTransfer, useCleanupTransfers, type Transfer } from '@/hooks/useTransfers';
 import { useWebhookNotifications, type WebhookNotification, useRenameNotifications } from '@/hooks/useWebhooks';
 import { ConnectionStatusBar } from '@/components/dashboard/connection-status-bar';
@@ -79,36 +79,14 @@ const dashboardPanelHeaderClass =
   'flex items-center justify-between border-b border-border/70 bg-muted/35 px-4 py-3';
 
 export function DashboardPage() {
-  const runtime = useRuntimeConnection();
+  const runtime = useRuntimeController();
   const wsStatus = useWebSocketStatus();
-
-  const autoConnect = useSSHAutoConnect();
-  const disconnect = useSSHDisconnect();
   const cleanupTransfers = useCleanupTransfers();
   const cancelTransfer = useCancelTransfer();
 
   const { data: activeTransfers, isLoading: transfersLoading, refetch: refetchTransfers } = useActiveTransfers();
   const { data: webhooks, isLoading: webhooksLoading, refetch: refetchWebhooks } = useWebhookNotifications(undefined, 10);
   const { data: renames, refetch: refetchRenames } = useRenameNotifications(10);
-
-  const handleReconnect = async () => {
-    try {
-      await autoConnect.mutateAsync();
-      runtime.reconnectSocket();
-      toast.success('Connected to server');
-    } catch {
-      toast.error('Connection failed');
-    }
-  };
-
-  const handleDisconnect = async () => {
-    try {
-      await disconnect.mutateAsync();
-      toast.success('Disconnected from server');
-    } catch {
-      toast.error('Failed to disconnect');
-    }
-  };
 
   const handleCleanup = async () => {
     try {
@@ -131,11 +109,13 @@ export function DashboardPage() {
   };
 
   const statusMessage = (() => {
-    if (runtime.connectionState === 'config-changed') return 'Configuration updated - reconnection required';
-    if (runtime.connectionState === 'auto-disconnected') return 'Connected to server - background monitoring active';
-    if (runtime.connectionState === 'connected') return `Connected to server - session ${runtime.minutesRemaining} min remaining`;
-    if (runtime.sshConnected && !runtime.socketConnected) return 'Connected to server - realtime updates unavailable';
-    return runtime.socketError ? `WebSocket error: ${runtime.socketError}` : 'Disconnected from server';
+    if (!runtime.backendReachable) return runtime.backendError || 'Backend unavailable';
+    if (runtime.connectionState === 'config-changed') return 'Realtime settings changed - reconnect to apply them';
+    if (runtime.connectionState === 'auto-disconnected') return 'Realtime paused after inactivity - dashboard polling remains active';
+    if (runtime.connectionState === 'connected') return `Realtime active - session ${runtime.minutesRemaining} min remaining`;
+    if (runtime.connectionState === 'connecting') return 'Connecting realtime session...';
+    if (runtime.connectionState === 'disconnected') return runtime.socketError ? `Realtime error: ${runtime.socketError}` : 'Realtime disconnected';
+    return 'Dashboard is using API polling. Enable realtime for cross-page live updates.';
   })();
 
   return (
@@ -146,12 +126,15 @@ export function DashboardPage() {
       </div>
 
       <ConnectionStatusBar
+        backendReachable={runtime.backendReachable}
         connectionState={runtime.connectionState}
         statusMessage={statusMessage}
         timeRemainingMinutes={runtime.minutesRemaining}
         activeSocketConnections={wsStatus.data?.websocket_status.active_connections}
-        onReconnect={handleReconnect}
-        onDisconnect={handleDisconnect}
+        realtimeRequested={runtime.realtimeRequested}
+        onEnableRealtime={runtime.enableRealtime}
+        onReconnect={runtime.reconnectRealtime}
+        onDisconnect={runtime.disableRealtime}
         onExtendSession={runtime.extendSession}
         onRefreshWsStatus={() => {
           wsStatus.refetch();
@@ -159,7 +142,7 @@ export function DashboardPage() {
           refetchWebhooks();
           refetchRenames();
         }}
-        isReconnecting={autoConnect.isPending}
+        isReconnecting={wsStatus.isFetching && runtime.realtimeRequested && !runtime.socketConnected}
       />
 
       <DiskUsageMonitor />

--- a/frontend/src/components/pages/media-browser.tsx
+++ b/frontend/src/components/pages/media-browser.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { Link } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import {
   useEpisodes,
@@ -8,6 +9,7 @@ import {
   useSeasons,
   useSyncStatus,
 } from '@/hooks/useMedia';
+import { useSSHConfig, useSSHAutoConnect, useSSHStatus } from '@/hooks/useConfig';
 import { useStartTransfer } from '@/hooks/useTransfers';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -28,6 +30,8 @@ import {
   IconPlayerPlay,
   IconRefresh,
   IconSearch,
+  IconSettings,
+  IconPlugConnected,
 } from '@tabler/icons-react';
 import type { DryRunResult, FolderMetadata, FolderSyncStatus, SyncStatusType } from '@/lib/api-types';
 
@@ -104,12 +108,19 @@ export function MediaBrowserPage({ mediaType }: MediaBrowserPageProps) {
   const [sortMode, setSortMode] = useState<SortMode>('recent');
   const [manualSyncRefresh, setManualSyncRefresh] = useState(false);
   const [dryRunResult, setDryRunResult] = useState<DryRunResult | null>(null);
+  const [autoConnectAttempted, setAutoConnectAttempted] = useState(false);
 
-  const foldersQuery = useFolders(mediaType);
-  const syncStatusQuery = useSyncStatus(mediaType);
-  const seasonsQuery = useSeasons(mediaType, selectedFolder ?? '');
-  const seasonSyncQuery = useFolderSyncStatus(mediaType, selectedFolder ?? '');
-  const episodesQuery = useEpisodes(mediaType, selectedFolder ?? '', selectedSeason ?? '');
+  const sshStatusQuery = useSSHStatus();
+  const sshConfigQuery = useSSHConfig();
+  const autoConnect = useSSHAutoConnect();
+  const sshConnected = Boolean(sshStatusQuery.data);
+  const hasStoredSshCredentials = Boolean(sshConfigQuery.data?.host && sshConfigQuery.data?.username);
+
+  const foldersQuery = useFolders(sshConnected ? mediaType : '');
+  const syncStatusQuery = useSyncStatus(sshConnected ? mediaType : '');
+  const seasonsQuery = useSeasons(sshConnected ? mediaType : '', selectedFolder ?? '');
+  const seasonSyncQuery = useFolderSyncStatus(sshConnected ? mediaType : '', selectedFolder ?? '');
+  const episodesQuery = useEpisodes(sshConnected ? mediaType : '', selectedFolder ?? '', selectedSeason ?? '');
 
   const startTransfer = useStartTransfer();
   const dryRun = useMediaDryRun();
@@ -120,7 +131,34 @@ export function MediaBrowserPage({ mediaType }: MediaBrowserPageProps) {
     setSelectedSeason(null);
     setSearchTerm('');
     setSortMode('recent');
+    setAutoConnectAttempted(false);
   }, [mediaType]);
+
+  useEffect(() => {
+    if (sshConnected || autoConnectAttempted || autoConnect.isPending) return;
+    if (sshStatusQuery.isLoading || sshConfigQuery.isLoading) return;
+    if (!hasStoredSshCredentials) return;
+
+    setAutoConnectAttempted(true);
+
+    autoConnect.mutate(undefined, {
+      onSuccess: () => {
+        sshStatusQuery.refetch();
+        toast.success('Remote browse session connected.');
+      },
+      onError: () => {
+        toast.error('Failed to auto-connect remote browse session. Check Settings.');
+      },
+    });
+  }, [
+    autoConnect,
+    autoConnectAttempted,
+    hasStoredSshCredentials,
+    sshConfigQuery.isLoading,
+    sshConnected,
+    sshStatusQuery,
+    sshStatusQuery.isLoading,
+  ]);
 
   const folders = foldersQuery.data?.folders ?? [];
   const seasons = seasonsQuery.data?.seasons ?? [];
@@ -267,16 +305,58 @@ export function MediaBrowserPage({ mediaType }: MediaBrowserPageProps) {
           <p className="text-neutral-400 mt-1">Static-parity media browse and transfer workflow</p>
         </div>
         <div className="flex gap-2">
-          <Button variant="outline" onClick={() => foldersQuery.refetch()} disabled={foldersQuery.isFetching}>
+          <Button variant="outline" onClick={() => foldersQuery.refetch()} disabled={!sshConnected || foldersQuery.isFetching}>
             <IconRefresh className={`h-4 w-4 mr-2 ${foldersQuery.isFetching ? 'animate-spin' : ''}`} />
             Refresh Folders
           </Button>
-          <Button variant="outline" onClick={refreshSyncStatus} disabled={isAnySyncLoading}>
+          <Button variant="outline" onClick={refreshSyncStatus} disabled={!sshConnected || isAnySyncLoading}>
             <IconRefresh className={`h-4 w-4 mr-2 ${isAnySyncLoading ? 'animate-spin' : ''}`} />
             Refresh Sync Status
           </Button>
         </div>
       </div>
+
+      {!sshConnected && !sshStatusQuery.isLoading && (
+        <Card className="border-amber-500/30 bg-amber-500/8">
+          <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-6">
+            <div>
+              <p className="text-sm font-medium text-amber-100">Remote browse session required</p>
+              <p className="mt-1 text-sm text-amber-50/80">
+                {hasStoredSshCredentials
+                  ? 'Media browsing uses the dedicated SSH browse connection. DragonCP can auto-connect with your saved SSH credentials, or you can review them in Settings.'
+                  : 'Media browsing uses the dedicated SSH browse connection. Add SSH host and username in Settings before exploring remote folders.'}
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {hasStoredSshCredentials && (
+                <Button
+                  variant="outline"
+                  className="border-amber-400/40 bg-background/40 text-amber-100 hover:bg-background/60"
+                  disabled={autoConnect.isPending}
+                  onClick={async () => {
+                    try {
+                      await autoConnect.mutateAsync();
+                      await sshStatusQuery.refetch();
+                      toast.success('Remote browse session connected.');
+                    } catch {
+                      toast.error('Failed to connect remote browse session.');
+                    }
+                  }}
+                >
+                  <IconPlugConnected className={`mr-2 h-4 w-4 ${autoConnect.isPending ? 'animate-pulse' : ''}`} />
+                  {autoConnect.isPending ? 'Connecting...' : 'Connect Browse Session'}
+                </Button>
+              )}
+              <Link to="/settings">
+                <Button variant="outline" className="border-amber-400/40 bg-background/40 text-amber-100 hover:bg-background/60">
+                  <IconSettings className="mr-2 h-4 w-4" />
+                  Open Settings
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       <div className="flex items-center flex-wrap gap-2 text-sm">
         {breadcrumb.map((entry, index) => {

--- a/frontend/src/components/pages/webhooks.tsx
+++ b/frontend/src/components/pages/webhooks.tsx
@@ -14,7 +14,7 @@ import {
   type RenameNotification,
   type WebhookNotification,
 } from '@/hooks/useWebhooks';
-import { onRenameCompleted, onRenameWebhookReceived, onWebhookReceived } from '@/services/socket';
+import { onRenameCompleted, onRenameWebhookReceived, onWebhookCaptured, onWebhookReceived } from '@/services/socket';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -197,6 +197,9 @@ export function WebhooksPage() {
   const deleteRenameMutation = useDeleteRenameNotification();
 
   useEffect(() => {
+    const offWebhookCaptured = onWebhookCaptured(() => {
+      notificationsQuery.refetch();
+    });
     const offRenameReceived = onRenameWebhookReceived(() => {
       renameQuery.refetch();
     });
@@ -205,16 +208,17 @@ export function WebhooksPage() {
     });
     const offTestWebhook = onWebhookReceived((payload) => {
       if (payload?.message) {
-        toast.info(payload.message);
+        notificationsQuery.refetch();
       }
     });
 
     return () => {
+      offWebhookCaptured();
       offRenameReceived();
       offRenameCompleted();
       offTestWebhook();
     };
-  }, [renameQuery]);
+  }, [notificationsQuery, renameQuery]);
 
   const notifications = notificationsQuery.data?.notifications ?? [];
   const items = useMemo(() => buildItems(notifications), [notifications]);

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -10,6 +10,9 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
+      offset={{ top: "4.5rem", right: "1.5rem", left: "1rem", bottom: "1rem" }}
+      mobileOffset={{ top: "4.75rem", right: "0.75rem", left: "0.75rem", bottom: "0.75rem" }}
+      visibleToasts={5}
       icons={{
         success: (
           <IconCircleCheck className="size-4" />
@@ -38,6 +41,8 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast: "cn-toast",
+          title: "cn-toast-title",
+          description: "cn-toast-description",
         },
       }}
       {...props}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { authApi } from '@/lib/api';
 import { useAuthStore } from '@/stores/auth';
-import { connectSocket, disconnectSocket } from '@/services/socket';
+import { destroySocket } from '@/services/socket';
 
 export function useLogin() {
   const login = useAuthStore((state) => state.login);
@@ -19,8 +19,6 @@ export function useLogin() {
     onSuccess: (data) => {
       if (data.token && data.refresh_token && data.user && data.expires_at) {
         login(data.token, data.refresh_token, data.user, data.expires_at);
-        // Connect WebSocket after login
-        connectSocket();
         navigate({ to: '/dashboard' });
       }
     },
@@ -41,7 +39,7 @@ export function useLogout() {
       }
     },
     onSettled: () => {
-      disconnectSocket();
+      destroySocket();
       logout();
       navigate({ to: '/login' });
     },

--- a/frontend/src/hooks/useConfig.ts
+++ b/frontend/src/hooks/useConfig.ts
@@ -1,7 +1,70 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
 import api from '@/lib/api';
 import type { AppConfig, DiskUsage, RemoteStorageInfo, SSHConfig, SSHConfigResponse } from '@/lib/api-types';
 export type { AppConfig, DiskUsage, RemoteStorageInfo, SSHConfig, SSHConfigResponse } from '@/lib/api-types';
+
+export interface RuntimeStatusResponse {
+  status: string;
+  runtime_status: {
+    backend_reachable: boolean;
+    ssh_connected: boolean;
+    websocket: {
+      active_connections: number;
+      cleanup_thread_running: boolean;
+      runtime: Record<string, unknown>;
+    };
+    timestamp: string;
+  };
+}
+
+interface LegacyDebugResponse {
+  status: string;
+  debug_info: {
+    ssh_connected: boolean;
+    websocket_info?: {
+      active_connections?: number;
+      cleanup_thread_running?: boolean;
+      runtime?: Record<string, unknown>;
+    };
+    timestamp?: string;
+  };
+}
+
+function normalizeLegacyRuntimeStatus(data: LegacyDebugResponse): RuntimeStatusResponse {
+  return {
+    status: data.status,
+    runtime_status: {
+      backend_reachable: true,
+      ssh_connected: Boolean(data.debug_info?.ssh_connected),
+      websocket: {
+        active_connections: data.debug_info?.websocket_info?.active_connections ?? 0,
+        cleanup_thread_running: Boolean(data.debug_info?.websocket_info?.cleanup_thread_running),
+        runtime: data.debug_info?.websocket_info?.runtime ?? {},
+      },
+      timestamp: data.debug_info?.timestamp ?? new Date().toISOString(),
+    },
+  };
+}
+
+function runtimeStatusQueryOptions() {
+  return {
+    queryKey: ['runtime', 'status'],
+    queryFn: async () => {
+      try {
+        const response = await api.get<RuntimeStatusResponse>('/runtime/status');
+        return response.data;
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status === 404) {
+          const fallback = await api.get<LegacyDebugResponse>('/debug');
+          return normalizeLegacyRuntimeStatus(fallback.data);
+        }
+        throw error;
+      }
+    },
+    refetchInterval: 5000,
+  };
+}
 
 export function useAppConfig() {
   return useQuery({
@@ -23,7 +86,7 @@ export function useUpdateConfig() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['config'] });
-      queryClient.invalidateQueries({ queryKey: ['ssh', 'status'] });
+      queryClient.invalidateQueries({ queryKey: ['runtime', 'status'] });
     },
   });
 }
@@ -38,7 +101,7 @@ export function useResetConfig() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['config'] });
-      queryClient.invalidateQueries({ queryKey: ['ssh', 'status'] });
+      queryClient.invalidateQueries({ queryKey: ['runtime', 'status'] });
     },
   });
 }
@@ -65,18 +128,13 @@ export function useSSHConfig() {
 
 export function useSSHStatus() {
   return useQuery({
-    queryKey: ['ssh', 'status'],
-    queryFn: async () => {
-      const response = await api.get<{
-        status: string;
-        debug_info: {
-          ssh_connected: boolean;
-        };
-      }>('/debug');
-      return response.data.debug_info.ssh_connected;
-    },
-    refetchInterval: 5000,
+    ...runtimeStatusQueryOptions(),
+    select: (data) => data.runtime_status.ssh_connected,
   });
+}
+
+export function useRuntimeStatus() {
+  return useQuery(runtimeStatusQueryOptions());
 }
 
 export function useSSHConnect() {
@@ -90,6 +148,7 @@ export function useSSHConnect() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['ssh'] });
       queryClient.invalidateQueries({ queryKey: ['media'] });
+      queryClient.invalidateQueries({ queryKey: ['runtime', 'status'] });
     },
   });
 }
@@ -105,7 +164,7 @@ export function useSSHAutoConnect() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['ssh'] });
       queryClient.invalidateQueries({ queryKey: ['media'] });
-      queryClient.invalidateQueries({ queryKey: ['ssh', 'status'] });
+      queryClient.invalidateQueries({ queryKey: ['runtime', 'status'] });
     },
   });
 }
@@ -121,7 +180,7 @@ export function useSSHDisconnect() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['ssh'] });
       queryClient.invalidateQueries({ queryKey: ['media'] });
-      queryClient.invalidateQueries({ queryKey: ['ssh', 'status'] });
+      queryClient.invalidateQueries({ queryKey: ['runtime', 'status'] });
     },
   });
 }

--- a/frontend/src/hooks/useConfig.ts
+++ b/frontend/src/hooks/useConfig.ts
@@ -4,6 +4,11 @@ import api from '@/lib/api';
 import type { AppConfig, DiskUsage, RemoteStorageInfo, SSHConfig, SSHConfigResponse } from '@/lib/api-types';
 export type { AppConfig, DiskUsage, RemoteStorageInfo, SSHConfig, SSHConfigResponse } from '@/lib/api-types';
 
+const RUNTIME_STATUS_REFETCH_MS = 5000;
+const LEGACY_DEBUG_REFETCH_MS = 30000;
+
+let runtimeStatusEndpointUnsupported = false;
+
 export interface RuntimeStatusResponse {
   status: string;
   runtime_status: {
@@ -51,18 +56,24 @@ function runtimeStatusQueryOptions() {
   return {
     queryKey: ['runtime', 'status'],
     queryFn: async () => {
+      if (runtimeStatusEndpointUnsupported) {
+        const fallback = await api.get<LegacyDebugResponse>('/debug');
+        return normalizeLegacyRuntimeStatus(fallback.data);
+      }
+
       try {
         const response = await api.get<RuntimeStatusResponse>('/runtime/status');
         return response.data;
       } catch (error) {
         if (axios.isAxiosError(error) && error.response?.status === 404) {
+          runtimeStatusEndpointUnsupported = true;
           const fallback = await api.get<LegacyDebugResponse>('/debug');
           return normalizeLegacyRuntimeStatus(fallback.data);
         }
         throw error;
       }
     },
-    refetchInterval: 5000,
+    refetchInterval: () => (runtimeStatusEndpointUnsupported ? LEGACY_DEBUG_REFETCH_MS : RUNTIME_STATUS_REFETCH_MS),
   };
 }
 

--- a/frontend/src/hooks/useRuntime.ts
+++ b/frontend/src/hooks/useRuntime.ts
@@ -203,6 +203,10 @@ export function useRuntimeConnection() {
     socket.on('disconnect', onDisconnect);
     socket.on('connect_error', onConnectError);
 
+    if (socket.connected) {
+      onConnect();
+    }
+
     return () => {
       socket.off('connect', onConnect);
       socket.off('disconnect', onDisconnect);
@@ -343,6 +347,7 @@ export function useRuntimeConnection() {
               hasCheckedTransferRef.current = true;
             }
             markActivity();
+            sendActivityPing();
             return;
           }
         } catch {

--- a/frontend/src/hooks/useRuntime.ts
+++ b/frontend/src/hooks/useRuntime.ts
@@ -1,21 +1,140 @@
 import { useEffect, useMemo, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
 import { toast } from 'sonner';
-import { useAppConfig, useSSHStatus } from '@/hooks/useConfig';
-import { connectSocket, disconnectSocket, getSocket, sendActivityPing } from '@/services/socket';
+import { useAppConfig, useRuntimeStatus } from '@/hooks/useConfig';
+import {
+  connectSocket,
+  disconnectSocket,
+  getSocket,
+  onRenameCompleted,
+  onRenameWebhookReceived,
+  onTransferComplete,
+  onTransferPromoted,
+  onTransferQueued,
+  onTransferUpdate,
+  onWebhookCaptured,
+  onWebhookReceived,
+  sendActivityPing,
+  type TransferUpdate,
+  type WebhookCapturedEvent,
+} from '@/services/socket';
 import { useRuntimeStore } from '@/stores/runtime';
 
 const ACTIVITY_EVENTS: Array<keyof DocumentEventMap> = ['click', 'keydown', 'submit', 'touchstart'];
 
-export function useRuntimeConnection() {
+function buildRealtimeStatusMessage(payload: TransferUpdate): string {
+  if (payload.message) return payload.message;
+  if (payload.progress) return payload.progress;
+  return `Transfer update for ${payload.transfer_id}`;
+}
+
+function buildWebhookToastMessage(payload: WebhookCapturedEvent): string {
+  if (payload.message) return payload.message;
+  if (payload.title) return `Webhook captured for ${payload.title}`;
+  return 'Webhook captured';
+}
+
+export function useRuntimeController() {
   const {
-    connectionState,
+    backendReachable,
+    backendError,
     sshConnected,
+    realtimeRequested,
     socketConnected,
     socketError,
+    connectionState,
     lastActivityAt,
     timeoutMinutes,
     wasAutoDisconnected,
+    configChanged,
+    liveActivityMessage,
+    liveActivityType,
+    liveActivityAt,
+    setAutoDisconnected,
+    setConfigChanged,
+    setRealtimeRequested,
+    setSocketConnected,
+    setSocketError,
+    markActivity,
+    clearLiveActivity,
+  } = useRuntimeStore();
+
+  const minutesRemaining = useMemo(() => {
+    if (!socketConnected) return 0;
+    const elapsedMs = Date.now() - lastActivityAt;
+    const remainingMs = timeoutMinutes * 60 * 1000 - elapsedMs;
+    return Math.max(0, Math.floor(remainingMs / 60000));
+  }, [lastActivityAt, socketConnected, timeoutMinutes]);
+
+  const enableRealtime = () => {
+    if (socketConnected) return;
+    setAutoDisconnected(false);
+    setConfigChanged(false);
+    setSocketError(null);
+    setRealtimeRequested(true);
+    connectSocket();
+    toast.success('Realtime updates enabled.');
+  };
+
+  const disableRealtime = () => {
+    setAutoDisconnected(false);
+    setConfigChanged(false);
+    setSocketError(null);
+    setRealtimeRequested(false);
+    setSocketConnected(false);
+    disconnectSocket();
+    clearLiveActivity();
+    toast.info('Realtime updates disabled.');
+  };
+
+  const reconnectRealtime = () => {
+    setAutoDisconnected(false);
+    setConfigChanged(false);
+    setSocketError(null);
+    setRealtimeRequested(true);
+    connectSocket();
+  };
+
+  const extendSession = () => {
+    if (!socketConnected) return;
+    markActivity();
+    sendActivityPing();
+    toast.success('Realtime session extended.');
+  };
+
+  return {
+    backendReachable,
+    backendError,
+    sshConnected,
+    realtimeRequested,
+    socketConnected,
+    socketError,
+    connectionState,
+    timeoutMinutes,
+    minutesRemaining,
+    wasAutoDisconnected,
+    configChanged,
+    liveActivityMessage,
+    liveActivityType,
+    liveActivityAt,
+    enableRealtime,
+    disableRealtime,
+    reconnectRealtime,
+    extendSession,
+  };
+}
+
+export function useRuntimeConnection() {
+  const queryClient = useQueryClient();
+  const { data: runtimeStatus, error: runtimeStatusError, isError: runtimeStatusIsError } = useRuntimeStatus();
+  const { data: config } = useAppConfig();
+  const {
+    realtimeRequested,
+    socketConnected,
+    lastActivityAt,
+    timeoutMinutes,
+    setBackendReachable,
     setSshConnected,
     setSocketConnected,
     setSocketError,
@@ -23,18 +142,24 @@ export function useRuntimeConnection() {
     setTimeoutMinutes,
     setAutoDisconnected,
     setConfigChanged,
+    setLiveActivity,
   } = useRuntimeStore();
-
-  const { data: sshStatus } = useSSHStatus();
-  const { data: config } = useAppConfig();
   const warningShownRef = useRef(false);
   const hasCheckedTransferRef = useRef(false);
+  const lastTransferActivityRef = useRef(0);
 
   useEffect(() => {
-    if (typeof sshStatus === 'boolean') {
-      setSshConnected(sshStatus);
+    if (runtimeStatus?.runtime_status) {
+      setBackendReachable(true, null);
+      setSshConnected(runtimeStatus.runtime_status.ssh_connected);
     }
-  }, [setSshConnected, sshStatus]);
+  }, [runtimeStatus, setBackendReachable, setSshConnected]);
+
+  useEffect(() => {
+    if (!runtimeStatusIsError) return;
+    const message = runtimeStatusError instanceof Error ? runtimeStatusError.message : 'Backend unavailable';
+    setBackendReachable(false, message);
+  }, [runtimeStatusError, runtimeStatusIsError, setBackendReachable]);
 
   useEffect(() => {
     const timeoutValue = Number(config?.WEBSOCKET_TIMEOUT_MINUTES ?? 30);
@@ -44,8 +169,15 @@ export function useRuntimeConnection() {
   }, [config?.WEBSOCKET_TIMEOUT_MINUTES, setTimeoutMinutes]);
 
   useEffect(() => {
+    if (!realtimeRequested) {
+      return;
+    }
+
     const socket = connectSocket();
-    if (!socket) return;
+    if (!socket) {
+      setSocketError('No auth token available for realtime session');
+      return;
+    }
 
     const onConnect = () => {
       setSocketConnected(true);
@@ -55,12 +187,14 @@ export function useRuntimeConnection() {
       hasCheckedTransferRef.current = false;
       markActivity();
     };
+
     const onDisconnect = (reason: string) => {
       setSocketConnected(false);
-      if (reason !== 'io client disconnect') {
+      if (reason !== 'io client disconnect' && realtimeRequested) {
         setSocketError(reason);
       }
     };
+
     const onConnectError = (error: Error) => {
       setSocketError(error.message);
     };
@@ -74,7 +208,7 @@ export function useRuntimeConnection() {
       socket.off('disconnect', onDisconnect);
       socket.off('connect_error', onConnectError);
     };
-  }, [markActivity, setConfigChanged, setSocketConnected, setSocketError]);
+  }, [markActivity, realtimeRequested, setConfigChanged, setSocketConnected, setSocketError]);
 
   useEffect(() => {
     if (!socketConnected) return;
@@ -85,7 +219,7 @@ export function useRuntimeConnection() {
       throttled = true;
       markActivity();
       sendActivityPing();
-      setTimeout(() => {
+      window.setTimeout(() => {
         throttled = false;
       }, 1500);
     };
@@ -102,6 +236,88 @@ export function useRuntimeConnection() {
   }, [markActivity, socketConnected]);
 
   useEffect(() => {
+    if (!realtimeRequested) return;
+
+    const socket = getSocket() ?? connectSocket();
+    if (!socket) return;
+
+    const unbindWebhookCaptured = onWebhookCaptured((payload) => {
+      const message = buildWebhookToastMessage(payload);
+      setLiveActivity('webhook', message);
+      toast.info(message);
+      queryClient.invalidateQueries({ queryKey: ['webhooks'] });
+    });
+
+    const unbindTestWebhook = onWebhookReceived((payload) => {
+      const message = payload?.message || 'Webhook connectivity verified';
+      setLiveActivity('webhook', message);
+      toast.info(message);
+    });
+
+    const unbindRenameReceived = onRenameWebhookReceived((payload) => {
+      const message = payload.series_title
+        ? `Rename webhook captured for ${payload.series_title}`
+        : 'Rename webhook captured';
+      setLiveActivity('rename', message);
+      toast.info(message);
+      queryClient.invalidateQueries({ queryKey: ['webhooks', 'rename'] });
+    });
+
+    const unbindRenameCompleted = onRenameCompleted((payload) => {
+      const message = payload.message || 'Rename flow completed';
+      setLiveActivity('rename', message);
+      toast.success(message);
+      queryClient.invalidateQueries({ queryKey: ['webhooks', 'rename'] });
+    });
+
+    const unbindTransferUpdate = onTransferUpdate((payload) => {
+      const now = Date.now();
+      if (now - lastTransferActivityRef.current < 2000) return;
+      lastTransferActivityRef.current = now;
+      setLiveActivity('transfer', buildRealtimeStatusMessage(payload));
+    });
+
+    const unbindTransferQueued = onTransferQueued((payload) => {
+      const message = buildRealtimeStatusMessage(payload);
+      setLiveActivity('transfer', message);
+      toast.info(message);
+      queryClient.invalidateQueries({ queryKey: ['transfers'] });
+      queryClient.invalidateQueries({ queryKey: ['webhooks'] });
+    });
+
+    const unbindTransferPromoted = onTransferPromoted((payload) => {
+      const message = buildRealtimeStatusMessage(payload);
+      setLiveActivity('transfer', message);
+      toast.success(message);
+      queryClient.invalidateQueries({ queryKey: ['transfers'] });
+      queryClient.invalidateQueries({ queryKey: ['webhooks'] });
+    });
+
+    const unbindTransferComplete = onTransferComplete((payload) => {
+      const message = buildRealtimeStatusMessage(payload);
+      setLiveActivity('transfer', message);
+      if (payload.status === 'failed') {
+        toast.error(message);
+      } else {
+        toast.success(message);
+      }
+      queryClient.invalidateQueries({ queryKey: ['transfers'] });
+      queryClient.invalidateQueries({ queryKey: ['webhooks'] });
+    });
+
+    return () => {
+      unbindWebhookCaptured();
+      unbindTestWebhook();
+      unbindRenameReceived();
+      unbindRenameCompleted();
+      unbindTransferUpdate();
+      unbindTransferQueued();
+      unbindTransferPromoted();
+      unbindTransferComplete();
+    };
+  }, [queryClient, realtimeRequested, setLiveActivity]);
+
+  useEffect(() => {
     const interval = window.setInterval(async () => {
       if (!socketConnected) return;
 
@@ -111,7 +327,7 @@ export function useRuntimeConnection() {
 
       if (remainingMs <= 2 * 60 * 1000 && remainingMs > 60 * 1000 && !warningShownRef.current) {
         warningShownRef.current = true;
-        toast.warning(`Real-time connection will disconnect in ${Math.ceil(remainingMs / 60000)} minute(s) due to inactivity.`);
+        toast.warning(`Realtime connection will disconnect in ${Math.ceil(remainingMs / 60000)} minute(s) due to inactivity.`);
       }
 
       if (remainingMs <= 0) {
@@ -123,58 +339,22 @@ export function useRuntimeConnection() {
           const hasActiveTransfers = Array.isArray(response.data.transfers) && response.data.transfers.length > 0;
           if (hasActiveTransfers) {
             if (!hasCheckedTransferRef.current) {
-              toast.info('Session timeout prevented because active transfers are running.');
+              toast.info('Realtime session timeout prevented because active transfers are running.');
               hasCheckedTransferRef.current = true;
             }
             markActivity();
             return;
           }
         } catch {
-          // Fallback: keep default behavior and disconnect socket.
+          // Keep default behavior and disconnect realtime.
         }
 
         disconnectSocket();
         setAutoDisconnected(true);
-        toast.info('Real-time connection disconnected due to inactivity. Background monitoring remains available.');
+        toast.info('Realtime connection disconnected due to inactivity. Dashboard polling remains active.');
       }
     }, 15000);
 
     return () => window.clearInterval(interval);
   }, [lastActivityAt, markActivity, setAutoDisconnected, socketConnected, timeoutMinutes]);
-
-  const minutesRemaining = useMemo(() => {
-    if (!socketConnected) return 0;
-    const elapsedMs = Date.now() - lastActivityAt;
-    const remainingMs = timeoutMinutes * 60 * 1000 - elapsedMs;
-    return Math.max(0, Math.floor(remainingMs / 60000));
-  }, [lastActivityAt, socketConnected, timeoutMinutes]);
-
-  const extendSession = () => {
-    if (!socketConnected) return;
-    warningShownRef.current = false;
-    hasCheckedTransferRef.current = false;
-    markActivity();
-    sendActivityPing();
-    toast.success('Session extended successfully.');
-  };
-
-  const reconnectSocket = () => {
-    const existing = getSocket();
-    if (existing?.connected) return;
-    setAutoDisconnected(false);
-    setConfigChanged(false);
-    connectSocket();
-  };
-
-  return {
-    connectionState,
-    sshConnected,
-    socketConnected,
-    socketError,
-    timeoutMinutes,
-    minutesRemaining,
-    wasAutoDisconnected,
-    extendSession,
-    reconnectSocket,
-  };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -127,3 +127,66 @@
     @apply font-sans;
     }
 }
+
+@layer components {
+  .toaster {
+    --toast-gap: 0.75rem;
+  }
+
+  .toaster [data-sonner-toaster] {
+    width: min(24rem, calc(100vw - 2rem));
+  }
+
+  .toaster [data-sonner-toaster][data-y-position="top"] {
+    top: calc(3.5rem + 0.35rem) !important;
+  }
+
+  .toaster [data-sonner-toast].cn-toast {
+    border: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
+    background:
+      linear-gradient(180deg, color-mix(in oklab, var(--background) 92%, #0b1120 8%) 0%, color-mix(in oklab, var(--background) 97%, transparent) 100%);
+    box-shadow:
+      0 22px 42px -30px rgba(15, 23, 42, 0.95),
+      0 10px 22px -18px rgba(99, 102, 241, 0.3);
+    backdrop-filter: blur(18px);
+    border-radius: 1rem;
+    padding: 0.95rem 1rem;
+    margin-top: 0;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .toaster [data-sonner-toast].cn-toast::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, rgba(168, 85, 247, 0.45), transparent);
+    opacity: 0.9;
+  }
+
+  .toaster [data-sonner-toast].cn-toast [data-icon] {
+    color: color-mix(in oklab, var(--primary) 82%, white 18%);
+  }
+
+  .toaster .cn-toast-title {
+    color: var(--foreground);
+    font-weight: 700;
+    letter-spacing: 0.01em;
+  }
+
+  .toaster .cn-toast-description,
+  .toaster [data-sonner-toast].cn-toast [data-content] {
+    color: color-mix(in oklab, var(--foreground) 82%, transparent);
+  }
+
+  @media (min-width: 1024px) {
+    .toaster [data-sonner-toaster] {
+      width: min(25rem, calc(100vw - 22rem - 2rem));
+    }
+
+    .toaster [data-sonner-toaster][data-y-position="top"] {
+      top: calc(3.5rem + 0.5rem) !important;
+    }
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 import { useAuthStore, shouldRefreshToken } from '@/stores/auth';
-import { disconnectSocket, reAuthenticateSocket } from '@/services/socket';
+import { destroySocket, reAuthenticateSocket } from '@/services/socket';
 
 // Create axios instance
 export const api = axios.create({
@@ -55,7 +55,7 @@ api.interceptors.response.use(
   (error: AxiosError) => {
     if (error.response?.status === 401) {
       // Token is invalid or expired, logout user
-      disconnectSocket();
+      destroySocket();
       useAuthStore.getState().logout();
       
       // Redirect to login page if not already there

--- a/frontend/src/routes/_authenticated.tsx
+++ b/frontend/src/routes/_authenticated.tsx
@@ -1,7 +1,5 @@
 import { createFileRoute, redirect, Outlet } from '@tanstack/react-router';
 import { useAuthStore } from '@/stores/auth';
-import { useEffect } from 'react';
-import { connectSocket, disconnectSocket } from '@/services/socket';
 import { AppLayout } from '@/components/layout/app-layout';
 import { useRuntimeConnection } from '@/hooks/useRuntime';
 
@@ -16,18 +14,7 @@ export const Route = createFileRoute('/_authenticated')({
 });
 
 function AuthenticatedLayout() {
-  const { isAuthenticated } = useAuthStore();
   useRuntimeConnection();
-
-  useEffect(() => {
-    if (isAuthenticated) {
-      connectSocket();
-    }
-
-    return () => {
-      disconnectSocket();
-    };
-  }, [isAuthenticated]);
 
   return (
     <AppLayout>

--- a/frontend/src/services/socket.ts
+++ b/frontend/src/services/socket.ts
@@ -37,6 +37,15 @@ export interface WebhookNotification {
   timestamp: string;
 }
 
+export interface WebhookCapturedEvent {
+  notification_id?: string;
+  title?: string;
+  media_type?: string;
+  auto_sync?: boolean;
+  message?: string;
+  timestamp?: string;
+}
+
 export interface RenameWebhookEvent {
   series_title?: string;
   total_files?: number;
@@ -133,6 +142,12 @@ export function connectSocket(): Socket | null {
 export function disconnectSocket(): void {
   if (socket) {
     socket.disconnect();
+  }
+}
+
+export function destroySocket(): void {
+  if (socket) {
+    socket.disconnect();
     socket = null;
   }
 }
@@ -202,6 +217,13 @@ export function onWebhookReceived(callback: (data: WebhookNotification) => void)
   
   socket.on('test_webhook_received', callback);
   return () => socket?.off('test_webhook_received', callback);
+}
+
+export function onWebhookCaptured(callback: (data: WebhookCapturedEvent) => void): () => void {
+  if (!socket) return () => {};
+
+  socket.on('webhook_received', callback);
+  return () => socket?.off('webhook_received', callback);
 }
 
 export function onRenameWebhookReceived(callback: (data: RenameWebhookEvent) => void): () => void {

--- a/frontend/src/stores/runtime.ts
+++ b/frontend/src/stores/runtime.ts
@@ -1,9 +1,13 @@
 import { create } from 'zustand';
 
-export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'auto-disconnected' | 'config-changed';
+export type ConnectionState = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'auto-disconnected' | 'config-changed';
+export type LiveActivityType = 'transfer' | 'webhook' | 'rename' | 'info' | null;
 
 interface RuntimeState {
+  backendReachable: boolean;
+  backendError: string | null;
   sshConnected: boolean;
+  realtimeRequested: boolean;
   socketConnected: boolean;
   socketError: string | null;
   connectionState: ConnectionState;
@@ -11,73 +15,128 @@ interface RuntimeState {
   timeoutMinutes: number;
   wasAutoDisconnected: boolean;
   configChanged: boolean;
+  liveActivityMessage: string | null;
+  liveActivityType: LiveActivityType;
+  liveActivityAt: number | null;
+  setBackendReachable: (value: boolean, error?: string | null) => void;
   setSshConnected: (value: boolean) => void;
+  setRealtimeRequested: (value: boolean) => void;
   setSocketConnected: (value: boolean) => void;
   setSocketError: (error: string | null) => void;
   markActivity: () => void;
   setTimeoutMinutes: (minutes: number) => void;
   setAutoDisconnected: (value: boolean) => void;
   setConfigChanged: (value: boolean) => void;
+  setLiveActivity: (type: Exclude<LiveActivityType, null>, message: string) => void;
+  clearLiveActivity: () => void;
   resetRuntime: () => void;
 }
 
-function deriveState(state: Pick<RuntimeState, 'sshConnected' | 'socketConnected' | 'wasAutoDisconnected' | 'configChanged'>): ConnectionState {
+function deriveState(
+  state: Pick<RuntimeState, 'realtimeRequested' | 'socketConnected' | 'wasAutoDisconnected' | 'configChanged' | 'socketError'>,
+): ConnectionState {
+  if (state.socketConnected && state.configChanged) return 'config-changed';
+  if (state.socketConnected) return 'connected';
+  if (state.wasAutoDisconnected) return 'auto-disconnected';
+  if (!state.realtimeRequested) return 'idle';
   if (state.configChanged) return 'config-changed';
-  if (state.socketConnected && state.sshConnected) return 'connected';
-  if (!state.socketConnected && state.sshConnected && state.wasAutoDisconnected) return 'auto-disconnected';
-  if (!state.socketConnected && state.sshConnected) return 'disconnected';
-  if (state.socketConnected) return 'connecting';
-  return 'disconnected';
+  if (state.socketError) return 'disconnected';
+  return 'connecting';
 }
 
 export const useRuntimeStore = create<RuntimeState>((set, get) => ({
+  backendReachable: true,
+  backendError: null,
   sshConnected: false,
+  realtimeRequested: false,
   socketConnected: false,
   socketError: null,
-  connectionState: 'connecting',
+  connectionState: 'idle',
   lastActivityAt: Date.now(),
   timeoutMinutes: 30,
   wasAutoDisconnected: false,
   configChanged: false,
-  setSshConnected: (value) =>
+  liveActivityMessage: null,
+  liveActivityType: null,
+  liveActivityAt: null,
+  setBackendReachable: (value, error = null) =>
+    set({
+      backendReachable: value,
+      backendError: value ? null : error,
+    }),
+  setSshConnected: (value) => set({ sshConnected: value }),
+  setRealtimeRequested: (value) =>
     set((prev) => ({
-      sshConnected: value,
-      connectionState: deriveState({ ...prev, sshConnected: value }),
+      realtimeRequested: value,
+      wasAutoDisconnected: value ? false : prev.wasAutoDisconnected,
+      connectionState: deriveState({
+        ...prev,
+        realtimeRequested: value,
+        wasAutoDisconnected: value ? false : prev.wasAutoDisconnected,
+      }),
     })),
   setSocketConnected: (value) =>
     set((prev) => ({
       socketConnected: value,
       wasAutoDisconnected: value ? false : prev.wasAutoDisconnected,
       socketError: value ? null : prev.socketError,
-      connectionState: deriveState({ ...prev, socketConnected: value, wasAutoDisconnected: value ? false : prev.wasAutoDisconnected }),
+      connectionState: deriveState({
+        ...prev,
+        socketConnected: value,
+        wasAutoDisconnected: value ? false : prev.wasAutoDisconnected,
+      }),
     })),
   setSocketError: (error) =>
     set((prev) => ({
       socketError: error,
-      connectionState: deriveState(prev),
+      connectionState: deriveState({ ...prev, socketError: error }),
     })),
   markActivity: () => set({ lastActivityAt: Date.now() }),
   setTimeoutMinutes: (minutes) => set({ timeoutMinutes: Math.max(5, Math.min(60, minutes)) }),
   setAutoDisconnected: (value) =>
     set((prev) => ({
       wasAutoDisconnected: value,
+      realtimeRequested: value ? false : prev.realtimeRequested,
       socketConnected: value ? false : prev.socketConnected,
-      connectionState: deriveState({ ...prev, wasAutoDisconnected: value, socketConnected: value ? false : prev.socketConnected }),
+      connectionState: deriveState({
+        ...prev,
+        wasAutoDisconnected: value,
+        realtimeRequested: value ? false : prev.realtimeRequested,
+        socketConnected: value ? false : prev.socketConnected,
+      }),
     })),
   setConfigChanged: (value) =>
     set((prev) => ({
       configChanged: value,
       connectionState: deriveState({ ...prev, configChanged: value }),
     })),
+  setLiveActivity: (type, message) =>
+    set({
+      liveActivityType: type,
+      liveActivityMessage: message,
+      liveActivityAt: Date.now(),
+    }),
+  clearLiveActivity: () =>
+    set({
+      liveActivityType: null,
+      liveActivityMessage: null,
+      liveActivityAt: null,
+    }),
   resetRuntime: () =>
     set({
+      backendReachable: true,
+      backendError: null,
       sshConnected: false,
+      realtimeRequested: false,
       socketConnected: false,
       socketError: null,
-      connectionState: 'disconnected',
+      connectionState: 'idle',
       lastActivityAt: Date.now(),
       timeoutMinutes: get().timeoutMinutes,
       wasAutoDisconnected: false,
       configChanged: false,
+      liveActivityType: null,
+      liveActivityMessage: null,
+      liveActivityAt: null,
     }),
 }));

--- a/routes/debug.py
+++ b/routes/debug.py
@@ -37,6 +37,30 @@ def init_debug_routes(app_config, app_ssh_manager, app_db_manager, app_transfer_
     socketio_runtime_info = app_socketio_runtime_info or {}
 
 
+@debug_bp.route('/runtime/status')
+@require_auth
+def api_runtime_status():
+    """Lightweight runtime status for normal frontend connection state."""
+    from websocket import get_cleanup_thread_status, get_websocket_connection_count
+
+    if config is None:
+        return _service_not_initialized_response("Config service")
+
+    return jsonify({
+        "status": "success",
+        "runtime_status": {
+            "backend_reachable": True,
+            "ssh_connected": ssh_manager.connected if ssh_manager else False,
+            "websocket": {
+                "active_connections": get_websocket_connection_count(),
+                "cleanup_thread_running": get_cleanup_thread_status(),
+                "runtime": socketio_runtime_info,
+            },
+            "timestamp": datetime.now().isoformat(),
+        },
+    })
+
+
 @debug_bp.route('/debug')
 @require_auth
 def api_debug():

--- a/routes/webhooks.py
+++ b/routes/webhooks.py
@@ -5,6 +5,7 @@ Handles webhook receivers for Radarr/Sonarr and webhook management
 """
 
 import os
+import logging
 from datetime import datetime
 from flask import Blueprint, jsonify, request, Response
 import requests
@@ -17,6 +18,26 @@ webhooks_bp = Blueprint('webhooks', __name__)
 config = None
 transfer_coordinator = None
 rename_service = None
+
+logger = logging.getLogger(__name__)
+
+
+def emit_socketio_event(event_name, payload, **context):
+    """Emit websocket notifications best-effort without breaking webhook success."""
+    if not transfer_coordinator or not transfer_coordinator.socketio:
+        return
+
+    try:
+        transfer_coordinator.socketio.emit(event_name, payload)
+    except Exception:
+        logger.exception(
+            "Socket.IO emit failed for %s (notification_id=%s, title=%s, media_type=%s, is_test=%s)",
+            event_name,
+            context.get('notification_id'),
+            context.get('title'),
+            context.get('media_type'),
+            context.get('is_test', False),
+        )
 
 
 def init_webhook_routes(app_config, app_transfer_coordinator, app_rename_service=None):
@@ -60,11 +81,17 @@ def api_webhook_movies_receiver():
         if is_test:
             print(f"🧪 TEST webhook received - webhook connectivity verified")
             # Emit toast notification via WebSocket
-            if transfer_coordinator.socketio:
-                transfer_coordinator.socketio.emit('test_webhook_received', {
+            emit_socketio_event(
+                'test_webhook_received',
+                {
                     'message': 'TEST webhook received - webhook connectivity verified',
                     'timestamp': datetime.now().isoformat()
-                })
+                },
+                notification_id=None,
+                title=title,
+                media_type='movies',
+                is_test=True,
+            )
             return jsonify({
                 "status": "success",
                 "message": "TEST webhook received - webhook connectivity verified",
@@ -84,15 +111,21 @@ def api_webhook_movies_receiver():
         except Exception:
             auto_sync_enabled = config.get("AUTO_SYNC_MOVIES", "false").lower() == "true"
 
-        if transfer_coordinator.socketio:
-            transfer_coordinator.socketio.emit('webhook_received', {
+        emit_socketio_event(
+            'webhook_received',
+            {
                 'notification_id': notification_id,
                 'title': parsed_data.get('title'),
                 'media_type': 'movies',
                 'auto_sync': auto_sync_enabled,
                 'message': f"Webhook captured for {parsed_data.get('title', 'movie')}",
                 'timestamp': datetime.now().isoformat(),
-            })
+            },
+            notification_id=notification_id,
+            title=parsed_data.get('title'),
+            media_type='movies',
+            auto_sync=auto_sync_enabled,
+        )
         
         if auto_sync_enabled:
             print(f"🎬 Auto-sync enabled, triggering sync for {parsed_data['title']}")
@@ -161,11 +194,17 @@ def api_webhook_series_receiver():
         
         if is_test:
             print(f"🧪 TEST series webhook received - webhook connectivity verified")
-            if transfer_coordinator.socketio:
-                transfer_coordinator.socketio.emit('test_webhook_received', {
+            emit_socketio_event(
+                'test_webhook_received',
+                {
                     'message': 'TEST series webhook received - webhook connectivity verified',
                     'timestamp': datetime.now().isoformat()
-                })
+                },
+                notification_id=None,
+                title=title,
+                media_type='tvshows',
+                is_test=True,
+            )
             return jsonify({
                 "status": "success",
                 "message": "TEST series webhook received - webhook connectivity verified",
@@ -199,15 +238,21 @@ def api_webhook_series_receiver():
         # Check if auto-sync is enabled for series
         auto_sync_enabled = transfer_coordinator.settings.get_bool('AUTO_SYNC_SERIES', False)
 
-        if transfer_coordinator.socketio:
-            transfer_coordinator.socketio.emit('webhook_received', {
+        emit_socketio_event(
+            'webhook_received',
+            {
                 'notification_id': notification_id,
                 'title': parsed_data.get('series_title'),
                 'media_type': 'tvshows',
                 'auto_sync': auto_sync_enabled,
                 'message': f"Webhook captured for {parsed_data.get('series_title', 'series')}",
                 'timestamp': datetime.now().isoformat(),
-            })
+            },
+            notification_id=notification_id,
+            title=parsed_data.get('series_title'),
+            media_type='tvshows',
+            auto_sync=auto_sync_enabled,
+        )
         
         if auto_sync_enabled:
             print(f"📺 Series auto-sync enabled, scheduling auto-sync for {parsed_data['series_title']}")
@@ -273,11 +318,17 @@ def api_webhook_anime_receiver():
         
         if is_test:
             print(f"🧪 TEST anime webhook received - webhook connectivity verified")
-            if transfer_coordinator.socketio:
-                transfer_coordinator.socketio.emit('test_webhook_received', {
+            emit_socketio_event(
+                'test_webhook_received',
+                {
                     'message': 'TEST anime webhook received - webhook connectivity verified',
                     'timestamp': datetime.now().isoformat()
-                })
+                },
+                notification_id=None,
+                title=title,
+                media_type='anime',
+                is_test=True,
+            )
             return jsonify({
                 "status": "success",
                 "message": "TEST anime webhook received - webhook connectivity verified",
@@ -311,15 +362,21 @@ def api_webhook_anime_receiver():
         # Check if auto-sync is enabled for anime
         auto_sync_enabled = transfer_coordinator.settings.get_bool('AUTO_SYNC_ANIME', False)
 
-        if transfer_coordinator.socketio:
-            transfer_coordinator.socketio.emit('webhook_received', {
+        emit_socketio_event(
+            'webhook_received',
+            {
                 'notification_id': notification_id,
                 'title': parsed_data.get('series_title'),
                 'media_type': 'anime',
                 'auto_sync': auto_sync_enabled,
                 'message': f"Webhook captured for {parsed_data.get('series_title', 'anime')}",
                 'timestamp': datetime.now().isoformat(),
-            })
+            },
+            notification_id=notification_id,
+            title=parsed_data.get('series_title'),
+            media_type='anime',
+            auto_sync=auto_sync_enabled,
+        )
         
         if auto_sync_enabled:
             print(f"🍙 Anime auto-sync enabled, scheduling auto-sync for {parsed_data['series_title']}")

--- a/routes/webhooks.py
+++ b/routes/webhooks.py
@@ -24,11 +24,12 @@ logger = logging.getLogger(__name__)
 
 def emit_socketio_event(event_name, payload, **context):
     """Emit websocket notifications best-effort without breaking webhook success."""
-    if not transfer_coordinator or not transfer_coordinator.socketio:
+    socketio_instance = getattr(transfer_coordinator, 'socketio', None) if transfer_coordinator else None
+    if not socketio_instance:
         return
 
     try:
-        transfer_coordinator.socketio.emit(event_name, payload)
+        socketio_instance.emit(event_name, payload)
     except Exception:
         logger.exception(
             "Socket.IO emit failed for %s (notification_id=%s, title=%s, media_type=%s, is_test=%s)",

--- a/routes/webhooks.py
+++ b/routes/webhooks.py
@@ -83,6 +83,16 @@ def api_webhook_movies_receiver():
             auto_sync_enabled = transfer_coordinator.settings.get_bool('AUTO_SYNC_MOVIES', default=(config.get("AUTO_SYNC_MOVIES", "false").lower() == "true"))
         except Exception:
             auto_sync_enabled = config.get("AUTO_SYNC_MOVIES", "false").lower() == "true"
+
+        if transfer_coordinator.socketio:
+            transfer_coordinator.socketio.emit('webhook_received', {
+                'notification_id': notification_id,
+                'title': parsed_data.get('title'),
+                'media_type': 'movies',
+                'auto_sync': auto_sync_enabled,
+                'message': f"Webhook captured for {parsed_data.get('title', 'movie')}",
+                'timestamp': datetime.now().isoformat(),
+            })
         
         if auto_sync_enabled:
             print(f"🎬 Auto-sync enabled, triggering sync for {parsed_data['title']}")
@@ -188,6 +198,16 @@ def api_webhook_series_receiver():
         
         # Check if auto-sync is enabled for series
         auto_sync_enabled = transfer_coordinator.settings.get_bool('AUTO_SYNC_SERIES', False)
+
+        if transfer_coordinator.socketio:
+            transfer_coordinator.socketio.emit('webhook_received', {
+                'notification_id': notification_id,
+                'title': parsed_data.get('series_title'),
+                'media_type': 'tvshows',
+                'auto_sync': auto_sync_enabled,
+                'message': f"Webhook captured for {parsed_data.get('series_title', 'series')}",
+                'timestamp': datetime.now().isoformat(),
+            })
         
         if auto_sync_enabled:
             print(f"📺 Series auto-sync enabled, scheduling auto-sync for {parsed_data['series_title']}")
@@ -290,6 +310,16 @@ def api_webhook_anime_receiver():
         
         # Check if auto-sync is enabled for anime
         auto_sync_enabled = transfer_coordinator.settings.get_bool('AUTO_SYNC_ANIME', False)
+
+        if transfer_coordinator.socketio:
+            transfer_coordinator.socketio.emit('webhook_received', {
+                'notification_id': notification_id,
+                'title': parsed_data.get('series_title'),
+                'media_type': 'anime',
+                'auto_sync': auto_sync_enabled,
+                'message': f"Webhook captured for {parsed_data.get('series_title', 'anime')}",
+                'timestamp': datetime.now().isoformat(),
+            })
         
         if auto_sync_enabled:
             print(f"🍙 Anime auto-sync enabled, scheduling auto-sync for {parsed_data['series_title']}")


### PR DESCRIPTION
## Summary
- decouple backend reachability, realtime Socket.IO, and SSH browse state so the dashboard defaults to polling and realtime becomes an explicit shared session
- add a lightweight runtime status contract with frontend fallback behavior, then reuse it to stabilize header status, media browse auto-connect, and cross-page webhook/transfer activity handling
- refine the app shell UX with aligned branding, a shared live-status indicator, and header-integrated toast positioning for stacked notifications

## Notes
- validated the updated frontend by rebuilding the Docker image with `docker compose build frontend`
- validated backend syntax for the touched Python files with `venv/bin/python -m py_compile routes/debug.py routes/webhooks.py app.py`
- the frontend still falls back to `/api/debug` if `/api/runtime/status` is not deployed on the running backend yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand realtime controls (enable/disable/reconnect) and session extension in the UI.
  * Header/sidebar realtime and backend-reachability indicators with live activity labels.
  * Remote browse session flow with “Connect Browse Session” prompt and auto-connect attempts.
  * Real-time notification updates when webhooks are captured.

* **Documentation**
  * Added runtime status API endpoint and updated websocket status response schema.

* **Style**
  * Updated toast/toaster styling and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->