### PR TITLE
[v2.1.3] fix same-path queue promotion tracking

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ from flask import session, has_request_context
 
 
 # Application version for cache busting
-APP_VERSION = "2.1.0"
+APP_VERSION = "2.1.3"
 
 
 class DragonCPConfig:

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,8 @@ Use this file as the primary index for documentation under `docs/`. If you need 
 
 - `docs/database/v2_schema.md`
   - Current database schema documentation.
+- `docs/database/LEGACY_V2_MIGRATION_NOTES.md`
+  - Legacy v1-to-v2 migration notes, including older destructive migration assumptions.
 
 ### `/refactoring/`
 

--- a/docs/SYNC_APPLICATION_ANALYSIS.md
+++ b/docs/SYNC_APPLICATION_ANALYSIS.md
@@ -1,6 +1,6 @@
 # DragonCP Custom Sync Application: Logic and Implementation Analysis
 
-Last updated: 2026-02-16
+Last updated: 2026-03-19
 Scope: Backend sync application only (`frontend/` excluded)
 
 ## 1. What This System Is Doing
@@ -84,6 +84,11 @@ Queue states represented through transfer + webhook state coupling:
 - `QUEUED_PATH`: waiting on same destination path to be freed.
 - `QUEUED_SLOT`: waiting on global slot availability.
 
+Implementation details now in place:
+- queued transfer rows persist `queue_reason` (`path` or `slot`) in `transfers`
+- same-path promotions re-register queue ownership before rsync starts
+- startup rebuilds running transfer reservations from DB before resuming monitors
+
 Promotion behavior:
 - Path-specific promotion first (`services/queue_manager.py:190`).
 - General slot promotion second (`services/queue_manager.py:270`).
@@ -119,6 +124,9 @@ Primary tables:
 - `app_settings`: runtime toggles and notification configuration.
 
 State transitions for series/anime notifications are documented in model comments (`models/webhook.py:189`).
+
+Important current-state note:
+- manual-sync-required rows are still stored as `pending` plus `requires_manual_sync=1`; the explicit `MANUAL_SYNC_REQUIRED` status is planned but not yet normalized end-to-end.
 
 ## 7. Backup and Restore Logic
 
@@ -194,7 +202,7 @@ This design improves recoverability but adds filesystem walk overhead after each
 
 1. Logging storage redesign (`transfers_log` table or buffered append) and notification lookup optimization.
 2. Event-driven completion callbacks and queue-promotion query optimization.
-3. Scheduler persistence and state normalization (`MANUAL_SYNC_REQUIRED` consistency).
+3. Scheduler persistence, explicit manual-sync status normalization, and tighter completion propagation for series/anime.
 4. API contract cleanup for manual transfer endpoint and improved id generation.
 5. Observability and adaptive QoS policy rollout.
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -84,8 +84,11 @@ Webhook status values (combined):
 - `syncing`
 - `completed`
 - `failed`
-- `MANUAL_SYNC_REQUIRED`
 - `cancelled`
+
+Current implementation note:
+- series/anime manual-sync-required rows are not yet persisted as `MANUAL_SYNC_REQUIRED`
+- they currently remain `pending` with `requires_manual_sync=1` and `manual_sync_reason` populated
 
 ---
 
@@ -662,16 +665,19 @@ Output JSON:
   "transfers": [],
   "total": 0,
   "queue_status": {
-    "max_concurrent": 2,
+    "max_concurrent": 3,
     "running_count": 0,
     "queued_count": 0,
-    "available_slots": 2,
+    "available_slots": 3,
     "running_transfer_ids": [],
     "queued_transfer_ids": [],
     "active_destinations": []
   }
 }
 ```
+
+Implementation note:
+- `queue_status.active_destinations` currently contains the transfer IDs that own reserved destinations, not the normalized path strings themselves.
 
 ### GET `/transfers/queue/status`
 What it does: returns queue state only.
@@ -683,10 +689,10 @@ Output JSON:
 {
   "status": "success",
   "queue": {
-    "max_concurrent": 2,
+    "max_concurrent": 3,
     "running_count": 0,
     "queued_count": 0,
-    "available_slots": 2
+    "available_slots": 3
   }
 }
 ```

--- a/docs/auto-sync/v3_autosync_implementation.md
+++ b/docs/auto-sync/v3_autosync_implementation.md
@@ -121,9 +121,9 @@ Promotion order:
 - prefers transfers that are explicitly or implicitly path-queued
 - re-checks path ownership
 - re-registers the promoted transfer in queue-manager running state before start
-- updates transfer status to `pending`
-- updates linked series/anime webhook rows to `READY_FOR_TRANSFER`
-- starts the transfer through `TransferCoordinator.start_queued_transfer()`
+- hands the transfer to `TransferCoordinator.start_queued_transfer()`
+
+`start_queued_transfer()` then performs the actual state transition to `pending` / `syncing` after queue ownership has been confirmed.
 
 The re-registration step above is the production fix for issue `#40`.
 

--- a/docs/auto-sync/v3_autosync_implementation.md
+++ b/docs/auto-sync/v3_autosync_implementation.md
@@ -1,955 +1,260 @@
-# Series/Anime Auto-Sync Flow V3 Implementation
-
-## Overview
-
-Complete redesign of the series/anime auto-sync system with intelligent queue management, explicit state tracking, and dynamic queue type conversion. This implementation eliminates ambiguous states, prevents transfers from getting stuck, and ensures proper synchronization between transfer and webhook notification states.
-
-### Key Features
-
-- **Explicit Queue Type Tracking**: Added `queue_reason` field (`'path'` or `'slot'`) for reliable queue management
-- **Dynamic Queue Conversion**: QUEUED_SLOT transfers automatically convert to QUEUED_PATH when path conflicts emerge
-- **Tuple Return Pattern**: `start_transfer()` returns `(success, queue_type)` for immediate state determination
-- **Transfer-Webhook Sync**: Webhook notifications always reflect actual transfer state
-- **Path-Specific Promotion**: Only same-path completion triggers QUEUED_PATH promotion
-- **Comprehensive Logging**: Structured logs with service name, transfer_id, and notification_id
-- **Batching with Linkage**: Multiple episodes link to single transfer via `transfer_id`
-
-## Problems Solved
-
-### Issue 1: Unreliable Queue Type Detection
-
-**Problem**: System tried to determine queue type by re-reading transfer record and parsing `progress` field, but the field was empty when read back from database, causing incorrect QUEUED_SLOT/QUEUED_PATH detection.
-
-**Solution**: 
-- Added explicit `queue_reason` field (`'path'` or `'slot'`) to transfer records
-- Changed `start_transfer()` to return `(success, queue_type)` tuple
-- Webhook service uses returned queue type directly, no database re-read needed
-
-### Issue 2: QUEUED_SLOT Marked as DUPLICATE on Path Conflict
-
-**Problem**: When a QUEUED_SLOT transfer was promoted but found a path conflict (another transfer now running on same path), it was marked as `DUPLICATE` (terminal state), leaving it stuck forever.
-
-**Solution**: 
-- Modified `_promote_next_queued_transfer()` to convert QUEUED_SLOT → QUEUED_PATH when path conflict emerges
-- Updates `queue_reason` from `'slot'` to `'path'`
-- Syncs webhook notification status to QUEUED_PATH
-- Transfer stays in queue and is picked up by `_promote_same_path_queued()` later
-
-### Issue 3: Incorrect Completion Marking
-
-**Problem**: `mark_pending_by_series_season_completed()` marked ALL notifications with states `pending`, `syncing`, and `waiting_auto_sync` as completed. Episodes arriving during active sync were incorrectly marked completed.
-
-**Solution**: Only mark `SYNCING` notifications as completed (those actually in the transfer, linked via `transfer_id`). Keep `PENDING` and `READY_FOR_TRANSFER` notifications for next cycle.
-
-### Issue 4: Ambiguous State Names
-
-**Problem**: State names like `waiting_auto_sync` were ambiguous and unclear.
-
-**Solution**: 
-- Renamed `waiting_auto_sync` to `READY_FOR_TRANSFER` (clear: passed validation, ready for transfer service)
-- Added separate `QUEUED_SLOT` and `QUEUED_PATH` states (clear: why it's queued)
-- All states now have clear, descriptive names
-
-## Complete State Flow
-
-### Detailed Flow Diagram
-
-```
-┌──────────────────────────────────────────────────────────────────────────────┐
-│                    SERIES/ANIME AUTO-SYNC V3 FLOW                            │
-└──────────────────────────────────────────────────────────────────────────────┘
-
-1. WEBHOOK RECEPTION & BATCHING
-   ├─ Webhook arrives (Episode downloaded)
-   ├─ Store in series_webhook_notification table
-   ├─ Status: PENDING
-   └─ Auto-sync Scheduler: Batch episodes (60s window)
-      ├─ Episode 1 arrives at T+0s → PENDING
-      ├─ Episode 2 arrives at T+15s → PENDING (extends batch window to T+75s)
-      └─ Episode 3 arrives at T+40s → PENDING (extends batch window to T+100s)
-
-2. DRY-RUN VALIDATION (after batch window)
-   ├─ Perform rsync --dry-run on season folder
-   ├─ Check for file deletions and conflicts
-   │
-   ├─ PASS ✓
-   │  ├─ Mark ALL batched notifications: READY_FOR_TRANSFER
-   │  ├─ Link ALL notifications to same transfer_id
-   │  └─ Proceed to transfer initiation
-   │
-   └─ FAIL ✗
-      ├─ Mark ALL batched notifications: MANUAL_SYNC_REQUIRED
-      └─ Send Discord alert
-
-3. TRANSFER INITIATION (Coordinator.start_transfer)
-   ├─ Check [A]: Path conflict? (duplicate destination check)
-   ├─ Check [B]: Slot available? (< 3 concurrent transfers)
-   │
-   ├─ Path Conflict (A=YES)
-   │  ├─ Create transfer: status='queued', queue_reason='path'
-   │  ├─ Return: (True, 'QUEUED_PATH')
-   │  └─ Update webhook: QUEUED_PATH
-   │
-   ├─ Slot Full (A=NO, B=NO)
-   │  ├─ Create transfer: status='queued', queue_reason='slot'
-   │  ├─ Return: (True, 'QUEUED_SLOT')
-   │  └─ Update webhook: QUEUED_SLOT
-   │
-   └─ Both OK (A=NO, B=YES)
-      ├─ Create transfer: status='pending'
-      ├─ Start rsync process
-      ├─ Return: (True, 'running')
-      └─ Update webhook: SYNCING
-
-4. QUEUE PROMOTION (when transfer completes)
-   ├─ Transfer X completes (dest_path: /path/to/season)
-   ├─ Unregister from queue manager
-   │
-   ├─ Step 1: Check for QUEUED_PATH with SAME dest_path
-   │  ├─ Query: SELECT * WHERE status='queued' AND queue_reason='path' 
-   │  │         AND dest_path='/path/to/season' ORDER BY created_at
-   │  ├─ Found? → Promote oldest one → Start transfer
-   │  └─ Not found? → Continue to Step 2
-   │
-   └─ Step 2: Check for QUEUED_SLOT (any path)
-      ├─ Query: SELECT * WHERE status='queued' AND queue_reason='slot'
-      │         ORDER BY created_at
-      ├─ Found? → Re-validate path conflict
-      │  ├─ Path OK? → Promote → Start transfer
-      │  └─ Path conflict? → Convert to QUEUED_PATH
-      │     ├─ Update: queue_reason='slot' → 'path'
-      │     ├─ Update webhook: QUEUED_SLOT → QUEUED_PATH
-      │     └─ Skip (wait for path-specific promotion)
-      └─ Not found? → Done
-
-5. DYNAMIC QUEUE CONVERSION
-   ├─ Scenario: QUEUED_SLOT transfer promoted, but path now occupied
-   ├─ Instead of marking DUPLICATE (terminal state)
-   ├─ Convert: QUEUED_SLOT → QUEUED_PATH
-   │  ├─ Update transfer: queue_reason='slot' → 'path'
-   │  ├─ Update webhook: QUEUED_SLOT → QUEUED_PATH
-   │  └─ Will be picked up by path-specific promotion later
-   └─ This prevents transfers from getting stuck
-
-6. COMPLETION MARKING
-   ├─ Transfer completes successfully
-   ├─ Find ALL notifications with this transfer_id
-   ├─ Update ALL linked notifications: SYNCING → COMPLETED
-   └─ Notifications with other states (PENDING, READY_FOR_TRANSFER) stay unchanged
-```
-
-### Transfer Record Structure
-
-```
-transfers table:
-├─ transfer_id: "series_webhook_tvshows_267_s1_ef76577_1763970383"
-├─ status: 'queued' | 'pending' | 'running' | 'completed' | 'failed'
-├─ queue_reason: 'path' | 'slot' | NULL  ← NEW: Explicit queue type
-├─ progress: Human-readable message
-└─ dest_path: "/path/to/destination"
-
-series_webhook_notification table:
-├─ notification_id: "tvshows_267_s1_ef76577"
-├─ status: 'PENDING' | 'READY_FOR_TRANSFER' | 'QUEUED_SLOT' | 
-│          'QUEUED_PATH' | 'SYNCING' | 'COMPLETED' | 'FAILED'
-├─ transfer_id: Links to transfers table (for batched episodes)
-└─ season_path: "/source/path/Season 01"
-```
-
-### State Synchronization Pattern
-
-```
-Coordinator.start_transfer() returns:
-   ↓
-(success: bool, queue_type: str)
-   ↓
-   ├─ (True, 'running')      → Webhook: SYNCING
-   ├─ (True, 'QUEUED_SLOT')  → Webhook: QUEUED_SLOT
-   ├─ (True, 'QUEUED_PATH')  → Webhook: QUEUED_PATH
-   └─ (False, 'failed')      → Webhook: FAILED
-
-No database re-read needed - queue type is explicit and immediate
-```
-
-### All Possible States
-
-| State | Description | Transitions To | Terminal? |
-|-------|-------------|---------------|-----------|
-| `PENDING` | Webhook received, waiting for batch window | `READY_FOR_TRANSFER`, `MANUAL_SYNC_REQUIRED` | No |
-| `READY_FOR_TRANSFER` | Dry-run passed, ready for transfer service | `SYNCING`, `QUEUED_SLOT`, `QUEUED_PATH` | No |
-| `QUEUED_SLOT` | Blocked by max concurrent limit (3 transfers) | `READY_FOR_TRANSFER` | No |
-| `QUEUED_PATH` | Blocked by same destination path conflict | `READY_FOR_TRANSFER` | No |
-| `SYNCING` | Transfer actively in progress | `COMPLETED`, `FAILED`, `CANCELLED` | No |
-| `COMPLETED` | Transfer finished successfully | None | Yes |
-| `FAILED` | Transfer failed | None (can retry) | Yes |
-| `MANUAL_SYNC_REQUIRED` | Dry-run validation failed | None (needs user) | Yes |
-| `CANCELLED` | User cancelled transfer | None | Yes |
-
-### State Transition Rules
-
-1. **Batching (PENDING)**:
-    - Multiple webhooks for same series/season stay PENDING during wait window
-    - `auto_sync_scheduled_at` field tracks batch completion time
-    - All batched notifications validated together
-
-2. **Dry-Run Validation**:
-
-    - Performed ONCE per batch (entire season folder)
-    - ALL notifications in batch get same result (pass or fail)
-    - If passed: ALL move to `READY_FOR_TRANSFER`
-    - If failed: ALL move to `MANUAL_SYNC_REQUIRED`
-
-3. **Same-Path Grouping**:
-
-    - When marking `SYNCING`, mark ALL same-path `READY_FOR_TRANSFER` notifications
-    - When marking `QUEUED_PATH`, mark ALL same-path `READY_FOR_TRANSFER` notifications
-    - Ensures consistency (same destination = same state)
-
-4. **Completion Marking**:
-
-    - Only mark notifications with `SYNCING` state as `COMPLETED`
-    - `PENDING` notifications (arrived during sync) stay `PENDING` for next cycle
-    - `READY_FOR_TRANSFER` notifications stay for next attempt
-
-## Queue System Logic
-
-### Queue Types
-
-1. **Slot Queue (QUEUED_SLOT)**
-
-    - Reason: Max 3 concurrent transfers reached
-    - Promotion: When ANY transfer completes (slot freed)
-    - Priority: After path-specific queue
-
-2. **Path Queue (QUEUED_PATH)**
-
-    - Reason: Same destination path has active transfer
-    - Promotion: ONLY when SAME PATH transfer completes
-    - Priority: First (before general slot queue)
-
-### Queue Promotion Algorithm
-
-```python
-def _promote_next_queued_transfer():
-    """
-    Intelligent queue promotion with path-priority and dynamic conversion
-    """
-    # Get all queued transfers, sorted by creation time (FIFO)
-    queued_transfers = get_all_queued_transfers_sorted_by_time()
-    
-    for transfer in queued_transfers:
-        # Determine queue type from explicit queue_reason field
-        if transfer.queue_reason == 'path':
-            is_path_queue = True
-        elif transfer.queue_reason == 'slot':
-            is_path_queue = False
-        else:
-            # Fallback: parse progress message (legacy support)
-            is_path_queue = parse_progress_for_path_indicators(transfer.progress)
-        
-        # Re-check for path conflict before promoting
-        is_duplicate, existing_transfer_id = check_duplicate_destination(
-            transfer.dest_path, 
-            transfer.transfer_id
-        )
-        
-        if is_duplicate:
-            if is_path_queue:
-                # QUEUED_PATH transfer - path still occupied
-                # Skip and keep in queue (path-specific wait)
-                print(f"⏭️ Skipping QUEUED_PATH {transfer.id} (path occupied)")
-                continue
-            else:
-                # QUEUED_SLOT transfer - path conflict emerged!
-                # CRITICAL: Convert to QUEUED_PATH instead of marking DUPLICATE
-                print(f"🔄 Converting QUEUED_SLOT → QUEUED_PATH")
-                
-                update_transfer(transfer.id, {
-                    'queue_reason': 'path',  # slot → path
-                    'progress': 'Queued: Waiting for same path to complete'
-                })
-                
-                # Sync webhook notification status
-                update_webhook_notifications(transfer.id, {
-                    'status': 'QUEUED_PATH'
-                })
-                
-                # Skip promotion - will be picked up by path-specific check later
-                continue
-        
-        # Path is free - promote this transfer!
-        register_transfer(transfer.id, transfer.dest_path)
-        start_queued_transfer(transfer.id)
-        break  # Only promote one at a time
-```
-
-### Critical Edge Cases & Solutions
-
-**Case 1: Episode Arrives During Active Sync**
-
-```
-Timeline:
-T+0s:   Episode 1 downloaded → PENDING
-T+60s:  Validation passes → READY_FOR_TRANSFER → SYNCING
-T+90s:  Episode 2 downloaded → PENDING (new batch window)
-T+120s: Episode 1 still SYNCING
-T+150s: Episode 2 validation passes → READY_FOR_TRANSFER
-        Path check: Episode 1 still syncing same path
-        Result: Episode 2 → QUEUED_PATH
-T+180s: Episode 1 → COMPLETED
-        Promotion check: Found Episode 2 in QUEUED_PATH (same path)
-        Result: Episode 2 → SYNCING
-
-✓ Late-arriving episodes properly queued and picked up
-```
-
-**Case 2: Dynamic Queue Conversion (THE FIX)**
-
-```
-Initial State:
-- 3 transfers running (slots full)
-- Transfer A: QUEUED_SLOT (dest: /anime/SeriesX/S1)
-- Transfer B: QUEUED_SLOT (dest: /anime/SeriesX/S1) [SAME PATH as A]
-
-Slot Opens:
-- One transfer completes → slot freed
-- System attempts to promote Transfer A
-- Transfer A registers and starts → SYNCING
-- Queue manager tries to promote next → Transfer B
-
-Transfer B Promotion Attempt:
-1. Re-check path conflict
-2. Found: Transfer A now running on /anime/SeriesX/S1
-3. OLD BEHAVIOR: Mark Transfer B as DUPLICATE ❌
-4. NEW BEHAVIOR: Convert Transfer B: QUEUED_SLOT → QUEUED_PATH ✓
-   - Update queue_reason: 'slot' → 'path'
-   - Update webhook: QUEUED_SLOT → QUEUED_PATH
-   - Skip promotion (wait for Transfer A)
-
-Transfer A Completes:
-- Path-specific promotion check
-- Found: Transfer B in QUEUED_PATH for /anime/SeriesX/S1
-- Promote Transfer B → SYNCING ✓
-
-✓ Prevents transfers from getting stuck in DUPLICATE status
-✓ Dynamic queue type reflects actual blocking reason
-```
-
-**Case 3: Multiple Same-Path Queued Transfers**
-
-```
-Active Transfers (3/3 slots):
-- Transfer X: SYNCING (path: /anime/Series1/S1)
-- Transfer Y: SYNCING (path: /anime/Series2/S1)  
-- Transfer Z: SYNCING (path: /movies/Movie1)
-
-Queued Transfers:
-- Transfer A: QUEUED_PATH (path: /anime/Series1/S1) [same as X]
-- Transfer B: QUEUED_PATH (path: /anime/Series1/S1) [same as X]
-- Transfer C: QUEUED_SLOT (path: /anime/Series3/S1) [different]
-
-Event 1: Transfer Y completes (different path)
-├─ Check path-specific: No QUEUED_PATH for /anime/Series2/S1
-├─ Check slot queue: Transfer C found
-├─ Re-validate Transfer C: No path conflict
-└─ Result: Transfer C promoted → SYNCING
-
-Event 2: Transfer X completes (path: /anime/Series1/S1)
-├─ Check path-specific: Transfer A found (oldest, same path)
-├─ Promote Transfer A → SYNCING
-└─ Transfer B stays QUEUED_PATH (waits for A)
-
-Event 3: Transfer A completes (path: /anime/Series1/S1)
-├─ Check path-specific: Transfer B found (same path)
-├─ Promote Transfer B → SYNCING
-└─ Queue empty
-
-✓ Path-specific promotion ensures sequential processing
-✓ Oldest queued transfer for specific path always picked first
-```
-
-**Case 4: Batched Episodes with Transfer Linkage**
-
-```
-Batch 1 (Episodes 1, 2, 3):
-├─ 3 notifications created (each with unique notification_id)
-├─ All marked: PENDING
-├─ Validation passes → All marked: READY_FOR_TRANSFER
-├─ Transfer initiated: transfer_id = "series_webhook_..._1763970383"
-├─ Link ALL 3 notifications to this transfer_id
-└─ Update ALL 3: READY_FOR_TRANSFER → SYNCING
-
-Transfer Completes:
-├─ Query: SELECT * WHERE transfer_id = "series_webhook_..._1763970383"
-├─ Found: 3 notifications
-├─ Update ALL 3: SYNCING → COMPLETED
-└─ Only notifications in THIS transfer marked completed
-
-Batch 2 (Episode 4 - arrived late):
-├─ Still in PENDING state
-├─ NOT affected by Batch 1 completion
-└─ Will be processed in next cycle
-
-✓ Transfer-notification linkage ensures accurate completion marking
-✓ Only episodes actually synced are marked completed
-```
-
-## Implementation Details
-
-### Architecture Overview
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        Component Flow                           │
-└─────────────────────────────────────────────────────────────────┘
-
-Webhook Request
-   ↓
-WebhookService.parse_series_webhook_data()
-   ├─ Extract episode info
-   └─ Store in series_webhook_notification (PENDING)
-   ↓
-AutoSyncScheduler (manages batching)
-   ├─ Accumulate episodes (60s window)
-   ├─ Perform dry-run validation
-   └─ Mark: PENDING → READY_FOR_TRANSFER (or MANUAL_SYNC_REQUIRED)
-   ↓
-WebhookService.trigger_series_webhook_sync()
-   ├─ Link all batched notifications to transfer_id
-   └─ Call TransferCoordinator.start_transfer()
-   ↓
-TransferCoordinator.start_transfer() → returns (bool, queue_type)
-   ├─ Check path conflict → (True, 'QUEUED_PATH')
-   ├─ Check slot full → (True, 'QUEUED_SLOT')
-   └─ Both OK → (True, 'running')
-   ↓
-WebhookService (uses returned queue_type)
-   ├─ Map queue_type to webhook status
-   └─ Update all linked notifications
-   ↓
-QueueManager (when transfer completes)
-   ├─ Path-specific promotion (QUEUED_PATH)
-   ├─ Slot promotion with conversion (QUEUED_SLOT → QUEUED_PATH if needed)
-   └─ Call TransferCoordinator.start_queued_transfer()
-   ↓
-TransferService.start_rsync_process()
-   ├─ Execute rsync with monitoring
-   └─ Update transfer status: pending → running → completed
-   ↓
-WebhookService.update_webhook_transfer_status()
-   └─ Update all notifications linked to transfer_id: SYNCING → COMPLETED
-```
-
-### Modified Files
-
-#### 1. `models/webhook.py`
-
-**Changes:**
-
-- Fixed `mark_pending_by_series_season_completed()` to only mark `SYNCING` notifications
-- Added `link_notifications_to_transfer()` for batching support
-- Added `update_notifications_by_transfer_id()` for consistent status updates
-- Added `mark_notifications_completed_by_transfer()` for accurate completion
-- Comprehensive state documentation in class docstring
-
-**Key Methods:**
-
-```python
-def link_notifications_to_transfer(notification_ids: List[str], transfer_id: str):
-    """Link multiple batched notifications to a single transfer"""
-    
-def update_notifications_by_transfer_id(transfer_id: str, updates: dict):
-    """Update all notifications linked to a transfer (batched episodes)"""
-    
-def mark_notifications_completed_by_transfer(transfer_id: str):
-    """Mark only SYNCING notifications for this transfer as completed"""
-```
-
-#### 2. `services/queue_manager.py`
-
-**Changes:**
-
-- Added `dest_path` parameter to `unregister_transfer()` for path-specific promotion
-- Added `_promote_same_path_queued(dest_path)` for path-specific queue handling
-- **CRITICAL FIX**: Modified `_promote_next_queued_transfer()` to convert QUEUED_SLOT → QUEUED_PATH when path conflict emerges
-- Added explicit `queue_reason` field checking (primary), with fallback to progress parsing
-
-**Key Logic:**
-
-```python
-def _promote_next_queued_transfer():
-    """
-    Promotion with dynamic queue conversion
-    """
-    for transfer in queued_transfers:
-        # Check explicit queue_reason field (NEW)
-        if transfer.queue_reason == 'path':
-            is_path_queue = True
-        elif transfer.queue_reason == 'slot':
-            is_path_queue = False
-        
-        # Re-check for path conflict
-        is_duplicate, existing_id = check_duplicate_destination(...)
-        
-        if is_duplicate:
-            if is_path_queue:
-                # Already QUEUED_PATH - skip and keep waiting
-                continue
-            else:
-                # QUEUED_SLOT encountering path conflict
-                # CONVERT instead of marking DUPLICATE
-                update_transfer({
-                    'queue_reason': 'path',  # slot → path
-                    'progress': 'Queued: Waiting for same path'
-                })
-                
-                # Sync webhook status
-                update_webhook_notifications({'status': 'QUEUED_PATH'})
-                continue  # Skip, wait for path-specific promotion
-        
-        # Path free - promote!
-        promote_transfer(transfer)
-```
-
-#### 3. `services/transfer_coordinator.py`
-
-**Changes:**
-
-- **MAJOR**: Changed `start_transfer()` return type: `bool` → `Tuple[bool, str]`
-- Returns `(success, queue_type)` where queue_type is: `'running'`, `'QUEUED_SLOT'`, `'QUEUED_PATH'`, or `'failed'`
-- Added explicit `queue_reason` field to transfer records
-- Modified duplicate handling to create queued records (not failed)
-- Updated `_post_transfer_completion()` to pass `dest_path` for path-specific promotion
-
-**New Return Pattern:**
-
-```python
-def start_transfer(...) -> Tuple[bool, str]:
-    """
-    Start transfer and return explicit queue type
-    
-    Returns:
-        (success, queue_type) where queue_type is:
-        - 'running': Transfer started successfully
-        - 'QUEUED_SLOT': Queued due to max concurrent limit
-        - 'QUEUED_PATH': Queued due to path conflict  
-        - 'failed': Failed to start
-    """
-    
-    # Path conflict check
-    if is_duplicate:
-        transfer_data = {
-            'status': 'queued',
-            'queue_reason': 'path',  # Explicit tracking
-            'progress': 'Queued: Waiting for same path...'
-        }
-        create_transfer(transfer_data)
-        return (True, 'QUEUED_PATH')  # Explicit queue type
-    
-    # Slot availability check
-    can_start, queue_status = queue_manager.register_transfer(...)
-    if queue_status == 'queued':
-        transfer_data = {
-            'status': 'queued',
-            'queue_reason': 'slot',  # Explicit tracking
-            'progress': 'Waiting in queue...'
-        }
-        create_transfer(transfer_data)
-        return (True, 'QUEUED_SLOT')  # Explicit queue type
-    
-    # All checks passed - start immediately
-    if can_start:
-        create_and_start_transfer()
-        return (True, 'running')  # Started
-    
-    return (False, 'failed')  # Shouldn't reach here
-```
-
-#### 4. `services/webhook_service.py`
-
-**Changes:**
-
-- Updated `trigger_series_webhook_sync()` to unpack tuple return: `success, queue_type = start_transfer(...)`
-- **Eliminated database re-read**: Uses returned `queue_type` directly for webhook status
-- Added `batched_notification_ids` parameter for linking multiple episodes to single transfer
-- Updated `update_webhook_transfer_status()` to use `update_notifications_by_transfer_id()`
-- Replaced `_mark_pending_season_notifications_completed()` with `_mark_notifications_completed_by_transfer()`
-
-**New Pattern:**
-
-```python
-def trigger_series_webhook_sync(notification_id, batched_notification_ids):
-    """
-    Trigger sync with explicit queue type handling
-    """
-    # Link all batched notifications to transfer
-    link_notifications_to_transfer(batched_notification_ids, transfer_id)
-    
-    # Start transfer - returns explicit queue type
-    success, queue_type = coordinator.start_transfer(...)
-    
-    # Map queue type to webhook status (no DB re-read!)
-    webhook_status_map = {
-        'running': 'syncing',
-        'QUEUED_SLOT': 'QUEUED_SLOT',
-        'QUEUED_PATH': 'QUEUED_PATH'
-    }
-    
-    webhook_status = webhook_status_map.get(queue_type, 'syncing')
-    
-    # Update ALL linked notifications with same status
-    if webhook_status == 'syncing':
-        update_notifications_by_transfer_id(transfer_id, {
-            'status': 'syncing',
-            'synced_at': datetime.now()
-        })
-    elif webhook_status in ['QUEUED_SLOT', 'QUEUED_PATH']:
-        update_notifications_by_transfer_id(transfer_id, {
-            'status': webhook_status
-        })
-```
-
-#### 5. `services/auto_sync_scheduler.py`
-
-**Changes:**
-
-- Updated state transitions: `waiting_auto_sync` → `READY_FOR_TRANSFER`
-- Added `batched_notification_ids` tracking for linking episodes
-- Pass all batched notification IDs to `trigger_series_webhook_sync()`
-- Integrated `sync_logger` for structured logging
-
-**Batching Logic:**
-
-```python
-def _execute_job(job):
-    """
-    Execute scheduled job with batched notifications
-    """
-    notification_ids = job.notification_ids  # All batched episodes
-    
-    # Dry-run validation on entire season
-    validation_result = coordinator.perform_dry_run_validation(...)
-    
-    if validation_result['safe_to_sync']:
-        # Mark ALL batched notifications as READY_FOR_TRANSFER
-        for nid in notification_ids:
-            series_webhook_model.update(nid, {'status': 'READY_FOR_TRANSFER'})
-        
-        # Trigger sync with ALL notification IDs
-        # Coordinator will link them all to same transfer_id
-        success, message = coordinator.trigger_series_webhook_sync(
-            notification_id=notification_ids[0],
-            batched_notification_ids=notification_ids  # All IDs
-        )
-```
-
-**Future Enhancement - Sonarr API:**
-
-```python
-# TODO: Dynamic Wait Time with Sonarr API
-# GET /api/v3/queue?seriesId={series_id}
-# 
-# If queue has pending episodes for same season:
-#   - Extend wait time (up to max 15 min)
-# Else:
-#   - Proceed with dry-run immediately
-```
-
-#### 6. `services/sync_logger.py` (NEW FILE)
-
-**Purpose:** Structured logging utility for traceability
-
-**Key Functions:**
-
-```python
-def log_sync(service, message, notification_id=None, transfer_id=None, icon="📋"):
-    """
-    Log with consistent formatting
-    Format: 🔍 [Service] [notif:id][xfer:id] > message
-    """
-    
-def log_batch(service, batch_key, notification_ids, message, icon="📦"):
-    """Log batch processing events"""
-    
-def log_state_change(service, notification_id, old_status, new_status, 
-                     transfer_id=None, icon="🔄"):
-    """Log state transitions"""
-```
-
-**Usage:**
-```python
-log_sync("TransferCoordinator", "Checking for duplicate destination", 
-         transfer_id=transfer_id, icon="🔍")
-# Output: 🔍 [TransferCoordinator] [xfer:series_webhook_..._123] > Checking...
-
-log_state_change("WebhookService", notification_id, "QUEUED_SLOT", "QUEUED_PATH",
-                 transfer_id=transfer_id)
-# Output: 🔄 [WebhookService] [notif:tvshows_267_s1_abc][xfer:...] > 
-#         State change: QUEUED_SLOT -> QUEUED_PATH
-```
-
-### Database Schema
-
-**No schema changes required** - using existing TEXT columns for status.
-
-**New/Modified Fields:**
-
-#### `transfers` table:
-- `status`: `'queued'` | `'pending'` | `'running'` | `'completed'` | `'failed'` | `'cancelled'`
-- `queue_reason`: `'path'` | `'slot'` | `NULL` **(NEW)** - Explicit queue type tracking
-- `progress`: Human-readable message
-- `dest_path`: Destination path for duplicate detection
-
-#### `series_webhook_notifications` table:
-- `status`: State values (user-facing)
-  - `PENDING`
-  - `READY_FOR_TRANSFER` (replaces `waiting_auto_sync`)
-  - `QUEUED_SLOT` **(NEW)**
-  - `QUEUED_PATH` **(NEW)**
-  - `SYNCING`
-  - `COMPLETED`
-  - `FAILED`
-  - `MANUAL_SYNC_REQUIRED`
-  - `CANCELLED`
-- `transfer_id`: Links to `transfers.transfer_id` **(UTILIZED)** - For batching and accurate status updates
-- `season_path`: Source path for validation
-
-### State Marking Fix Details
-
-**File**: `models/webhook.py`, function `mark_pending_by_series_season_completed()`
-
-**Current (WRONG):**
-
-```python
-WHERE status IN ('pending', 'syncing', 'waiting_auto_sync')
-```
-
-**New (CORRECT):**
-
-```python
-WHERE status = 'syncing'
-```
-
-**Rationale**:
-
-- Only notifications actively being synced should be marked completed
-- `PENDING` notifications arrived late, need next sync cycle
-- `READY_FOR_TRANSFER` notifications haven't started yet
-- `QUEUED_*` notifications are waiting in queue
-
-## Implementation Steps
-
-1. **Add State Flow Documentation** (models/webhook.py)
-
-- Add comprehensive state documentation to class docstring
-- Document all possible states and transitions
-- Add state transition rules
-
-2. **Fix State Marking Logic** (models/webhook.py)
-
-- Modify `mark_pending_by_series_season_completed()`
-- Change SQL WHERE clause to only mark `SYNCING` as completed
-- Update function docstring with rationale
-
-3. **Add Same-Path Notification Marking** (models/webhook.py)
-
-- Add `mark_same_path_notifications_as_syncing()` method
-- Query READY_FOR_TRANSFER with same dest_path
-- Mark all as SYNCING when transfer starts
-
-4. **Enhance Queue Manager for Path-Specific Queuing** (services/queue_manager.py)
-
-- Add `dest_path` param to `unregister_transfer()`
-- Add `_promote_same_path_queued(dest_path)` method
-- Modify `_promote_next_queued_transfer()` to prioritize same-path queue
-
-5. **Update Transfer Coordinator** (services/transfer_coordinator.py)
-
-- Modify duplicate handling in `start_transfer()` to create queued records
-- Update `_post_transfer_completion()` to pass dest_path
-- Add logic to mark same-path notifications as SYNCING
-
-6. **Update Webhook Service State Mapping** (services/webhook_service.py)
-
-- Handle `QUEUED_SLOT` and `QUEUED_PATH` states
-- Ensure transfer state changes propagate to webhook notifications
-- Add state transition logging
-
-7. **Update Auto-Sync Scheduler** (services/auto_sync_scheduler.py)
-
-- Change `waiting_auto_sync` to `READY_FOR_TRANSFER`
-- Add Sonarr API TODO with implementation details
-- Update state transition calls
-
-8. **Frontend State Display** (static/modules/webhook-manager.js)
-
-- Add badges/colors for new states
-- Update state display logic
-- Add tooltips explaining queue types
-
-## Testing Scenarios
-
-1. **Basic Flow**: Single episode → PENDING → READY_FOR_TRANSFER → SYNCING → COMPLETED
-2. **Batching**: 3 episodes in 60s → All stay PENDING → All to READY_FOR_TRANSFER → All to SYNCING
-3. **Late Arrival**: Episode during sync → PENDING (stays) → Next cycle → READY_FOR_TRANSFER
-4. **Path Conflict**: Same path already syncing → QUEUED_PATH → Previous completes → SYNCING
-5. **Slot Full**: 3 transfers running → 4th → QUEUED_SLOT → Any completes → READY_FOR_TRANSFER
-6. **Sequential Same-Path**: Multiple queued for same path → Process one-by-one
-7. **Dry-Run Fail**: Batch fails validation → ALL → MANUAL_SYNC_REQUIRED
-
-## Design Decisions
-
-### Why Two State Tracking Approaches?
-
-**Transfers Table:** Generic `status='queued'` + Specific `queue_reason='path'|'slot'`
-
-**Webhook Table:** Specific `status='QUEUED_SLOT'|'QUEUED_PATH'`
-
-**Rationale:**
-1. **Backward Compatibility**: Transfers table used by movies (no queue types needed)
-2. **User Experience**: Webhook notifications directly displayed in UI (need clear labels)
-3. **Separation of Concerns**: Transfer system stays generic; webhook system is specific
-4. **Query Efficiency**: `queue_reason` provides metadata without changing core state machine
-
-### Why Tuple Return Pattern?
-
-**Old:** `start_transfer() → bool`
-- Required database re-read to determine queue type
-- Race condition: progress field could be empty
-- Unreliable queue type detection
-
-**New:** `start_transfer() → (bool, queue_type)`
-- Explicit, immediate queue type knowledge
-- No database round-trip needed
-- Reliable state synchronization
-- Clear contract: caller knows exactly what happened
-
-### Why Dynamic Queue Conversion?
-
-**Problem:** Transfers queued for slot availability can encounter path conflicts during promotion
-
-**Solution:** Convert QUEUED_SLOT → QUEUED_PATH dynamically
-- Reflects actual blocking reason
-- Prevents DUPLICATE terminal state
-- Ensures transfer eventually executes
-- User sees accurate queue reason in UI
-
-## Success Criteria
-
-- ✅ All webhook states clearly documented with transitions
-- ✅ State names are intuitive (`READY_FOR_TRANSFER`, `QUEUED_SLOT`, `QUEUED_PATH`)
-- ✅ Explicit queue type tracking via `queue_reason` field
-- ✅ Tuple return pattern eliminates database re-read race condition
-- ✅ Dynamic queue conversion prevents transfers from getting stuck
-- ✅ Path conflict transfers queue as `QUEUED_PATH`, not marked as duplicate
-- ✅ Only same-path transfer completion triggers `QUEUED_PATH` promotion
-- ✅ Only `SYNCING` notifications (linked via transfer_id) marked completed
-- ✅ Episodes arriving during sync stay `PENDING` for next cycle
-- ✅ Queue system handles both slot limits and path conflicts with automatic conversion
-- ✅ Structured logging with transfer_id and notification_id for full traceability
-- ✅ Frontend displays queue-specific states with clear labels
-
-## Known Limitations
-
-1. **Fixed Batch Window**: Currently uses 60s fixed window (Sonarr API integration documented as future enhancement)
-2. **Generic Transfer Status**: Transfer table uses `status='queued'` for backward compatibility (requires checking `queue_reason` for specifics)
-3. **No Queue Priority**: FIFO only (no prioritization by file size, age, or user preference)
-4. **Single-Level Queuing**: No nested queue priorities (e.g., high-priority path conflicts)
-
----
-
-## Git Commit Message
-
-```
-feat: Implement V3 series/anime auto-sync with intelligent queue management
-
-Complete redesign of series/anime auto-sync system with explicit state 
-tracking, dynamic queue conversion, and reliable transfer-webhook 
-synchronization. Eliminates race conditions and prevents transfers from 
-getting stuck in terminal states.
-
-### Major Changes
-
-**1. Explicit Queue Type Tracking**
-- Added `queue_reason` field ('path' or 'slot') to transfer records
-- Eliminates unreliable progress message parsing
-- Provides authoritative source for queue type determination
-
-**2. Tuple Return Pattern**
-- Changed `start_transfer()` signature: bool → (bool, queue_type)
-- Returns explicit queue type: 'running', 'QUEUED_SLOT', 'QUEUED_PATH', 'failed'
-- Eliminates database re-read race condition
-- Webhook service uses returned value directly for accurate state sync
-
-**3. Dynamic Queue Conversion**
-- QUEUED_SLOT transfers automatically convert to QUEUED_PATH when path 
-  conflicts emerge during promotion
-- Prevents transfers from being marked as DUPLICATE (terminal state)
-- Updates queue_reason field and webhook notification status
-- Ensures all transfers eventually execute
-
-**4. Transfer-Notification Linkage**
-- All batched episodes linked to single transfer via transfer_id
-- Consistent status updates across all notifications in a batch
-- Accurate completion marking using transfer_id instead of series/season matching
-- Prevents late-arriving episodes from being incorrectly marked completed
-
-**5. Path-Specific Promotion**
-- Queue manager prioritizes QUEUED_PATH transfers for specific destination paths
-- Only same-path completion triggers QUEUED_PATH promotion
-- Sequential processing of transfers to same destination
-- Slot-based promotion handled after path-specific checks
-
-**6. Comprehensive Logging**
-- New sync_logger utility for structured, traceable logs
-- Format: [Service][notif:id][xfer:id] > message
-- Full lifecycle tracking from webhook receipt to completion
-- Easy database query correlation
-
-### Files Modified
-
-**Core Services:**
-- services/transfer_coordinator.py: Tuple return pattern, explicit queue_reason
-- services/queue_manager.py: Dynamic conversion, path-specific promotion
-- services/webhook_service.py: Direct queue type usage, transfer linkage
-- services/auto_sync_scheduler.py: Batch notification ID tracking
-- services/sync_logger.py: NEW - Structured logging utility
-
-**Models:**
-- models/webhook.py: Transfer linkage methods, accurate completion marking
-
-**Frontend:**
-- static/modules/webhook-manager.js: QUEUED_SLOT and QUEUED_PATH badges
-
-### State Flow
-
-PENDING → READY_FOR_TRANSFER → {SYNCING | QUEUED_SLOT | QUEUED_PATH}
-                                      ↓          ↓            ↓
-                                  COMPLETED  (converts→)  (path-specific
-                                              QUEUED_PATH   promotion)
-
-### Fixes
-
-- ✅ No more stuck transfers in DUPLICATE status
-- ✅ Reliable queue type detection without database race conditions  
-- ✅ Accurate completion marking for batched episodes
-- ✅ Dynamic queue adaptation to emerging conflicts
-- ✅ Clear state names (READY_FOR_TRANSFER vs waiting_auto_sync)
-- ✅ Full traceability with structured logging
-
-### Breaking Changes
-
-None. Changes are backward compatible:
-- Generic transfer.status='queued' maintained for movie compatibility
-- New queue_reason field is optional metadata
-- Webhook states are additive (QUEUED_SLOT, QUEUED_PATH are new)
-
-### Future Enhancements
-
-- Sonarr API integration for dynamic batch windows
-- Queue priority system (by age, size, or user preference)
-- Multi-level queue priorities
-
-Closes issues with queue management, state synchronization, and transfer 
-completion accuracy for series/anime auto-sync workflow.
-```
+# Series/Anime Auto-Sync Flow V3
+
+Last updated: 2026-03-19
+Primary files: `routes/webhooks.py`, `services/auto_sync_scheduler.py`, `services/webhook_service.py`, `services/transfer_coordinator.py`, `services/queue_manager.py`, `models/webhook.py`
+
+## Purpose
+
+This document describes the current series/anime auto-sync path, including batching, dry-run validation, queueing, promotion, and webhook/transfer state synchronization.
+
+It also calls out the places where the implementation still differs from the original V3 target.
+
+## Current End-to-End Flow
+
+### 1. Webhook reception
+
+Series and anime Sonarr download events enter through:
+- `routes/webhooks.py` series receiver
+- `routes/webhooks.py` anime receiver
+
+For non-test, non-rename events:
+- payloads are parsed by `WebhookService.parse_series_webhook_data()`
+- a row is created in `sonarr_webhook`
+- the initial notification status is `pending`
+
+### 2. Auto-sync batching
+
+If auto-sync is enabled for the media type:
+- `TransferCoordinator.schedule_auto_sync()` delegates to `AutoSyncScheduler.schedule_job()`
+- jobs are grouped by `series_title_slug + season_number`
+- additional episodes for the same season extend the existing batch window
+- `auto_sync_scheduled_at` is stored on the notification rows
+
+Important current behavior:
+- scheduler jobs themselves are still in-memory only
+- the DB stores the next scheduled timestamp, but not a durable recoverable job record
+
+### 3. Dry-run validation
+
+When the batch window expires:
+- `AutoSyncScheduler._execute_job()` fetches the first notification in the batch
+- `TransferCoordinator.perform_dry_run_validation()` resolves the source season path
+- `PathService` computes the destination path using the same rules as real sync
+- `TransferService.perform_dry_run_rsync()` runs rsync dry-run safety checks
+
+If validation passes:
+- all batched notifications are updated to `READY_FOR_TRANSFER`
+- the scheduler calls `WebhookService.trigger_series_webhook_sync()`
+
+If validation fails:
+- each notification is updated through `TransferCoordinator.mark_for_manual_sync()`
+- current implementation keeps `status='pending'`
+- `requires_manual_sync=1` and `manual_sync_reason` hold the real manual-action signal
+- a Discord alert may be sent once for the batch
+
+This is one of the main remaining gaps versus the original V3 plan, which expected a real `MANUAL_SYNC_REQUIRED` status.
+
+## Transfer Creation and Queueing
+
+`WebhookService.trigger_series_webhook_sync()`:
+- creates one `transfer_id` for the batch
+- links all batched notifications to that `transfer_id`
+- resolves `source_path`, `dest_path`, `folder_name`, and `season_name`
+- calls `TransferCoordinator.start_transfer()`
+
+`TransferCoordinator.start_transfer()` returns `(success, queue_type)` where `queue_type` is:
+- `running`
+- `QUEUED_SLOT`
+- `QUEUED_PATH`
+- `failed`
+
+### Queue decision rules
+
+#### Path conflict
+
+If the destination path is already reserved:
+- a transfer row is created with `status='queued'`
+- `queue_reason='path'`
+- progress text explains the blocking transfer/path
+- the coordinator returns `QUEUED_PATH`
+- linked webhook notifications become `QUEUED_PATH`
+
+#### Slot full
+
+If no path conflict exists but all running slots are full:
+- a transfer row is created with `status='queued'`
+- `queue_reason='slot'`
+- the destination path is still reserved in memory
+- the coordinator returns `QUEUED_SLOT`
+- linked webhook notifications become `QUEUED_SLOT`
+
+#### Immediate start
+
+If the path is free and a slot is available:
+- the queue manager reserves the destination and running slot in memory
+- a transfer row is created with `status='pending'`
+- rsync starts
+- linked webhook notifications become `syncing`
+
+## Queue Reason Behavior
+
+`queue_reason` is now part of the real implementation, not just the design:
+- older databases get the `transfers.queue_reason` column automatically at startup
+- `Transfer.create()` persists `queue_reason` on insert
+- queue promotion logic uses `queue_reason` first
+- progress text parsing remains only as a legacy fallback
+
+This fixed the earlier mismatch where the code expected `queue_reason` but the schema/insert path did not actually store it.
+
+## Promotion Rules
+
+Promotion happens after `QueueManager.unregister_transfer()` removes a running transfer.
+
+Promotion order:
+1. same freed path first
+2. general slot queue second
+
+### Path-specific promotion
+
+`QueueManager._promote_same_path_queued(dest_path)`:
+- finds queued transfer rows for the same normalized destination path
+- prefers transfers that are explicitly or implicitly path-queued
+- re-checks path ownership
+- re-registers the promoted transfer in queue-manager running state before start
+- updates transfer status to `pending`
+- updates linked series/anime webhook rows to `READY_FOR_TRANSFER`
+- starts the transfer through `TransferCoordinator.start_queued_transfer()`
+
+The re-registration step above is the production fix for issue `#40`.
+
+### Slot promotion
+
+`QueueManager._promote_next_queued_transfer()`:
+- scans queued rows oldest-first
+- classifies each row as path-queue or slot-queue using `queue_reason` first
+- re-checks destination ownership before promotion
+
+If a slot-queued transfer now conflicts with a running transfer on the same path:
+- the transfer stays `queued`
+- `queue_reason` changes from `slot` to `path`
+- progress text is updated
+- linked notifications move from `QUEUED_SLOT` to `QUEUED_PATH`
+
+If the path is free:
+- queue state is reserved in memory
+- the transfer is promoted and started
+
+## Start of Promoted Transfers
+
+`TransferCoordinator.start_queued_transfer()` now performs a defensive check before rsync starts:
+- the transfer must already be represented in queue-manager running state
+- if queue state is missing, the transfer is not started
+
+After that check:
+- transfer status changes to `pending`
+- linked notifications for the `transfer_id` are updated to `syncing`
+- rsync starts
+- post-completion monitoring thread is started
+
+## Completion Marking
+
+### What is correct today
+
+The DB helper `SeriesWebhookNotification.mark_notifications_completed_by_transfer()` only updates rows where:
+- `transfer_id` matches
+- current status is `syncing`
+
+That is the right rule for V3 because it avoids incorrectly completing:
+- late-arriving `pending` notifications
+- validated-but-not-started `READY_FOR_TRANSFER` notifications
+- queued notifications still waiting on slot/path
+
+### What is still not fully aligned
+
+The broader series/anime completion path still bulk-updates linked notifications to `completed` before calling the stricter helper.
+
+So the data model contains the correct narrow completion primitive, but the full runtime path should still be tightened so only truly synced rows move to `completed`.
+
+## Restart and Recovery Behavior
+
+### What survives restart now
+
+Running transfer recovery improved:
+- queue-manager running reservations are rebuilt from DB rows marked `running`
+- monitoring of live rsync PIDs is resumed
+- post-completion watchers are restarted so queue release and downstream cleanup still happen
+
+### What still does not survive restart
+
+Scheduled auto-sync batch windows do not fully survive restart:
+- `auto_sync_scheduled_at` remains in the DB
+- in-memory scheduler jobs are lost
+- no startup recovery currently rebuilds them into `AutoSyncScheduler.jobs`
+
+This is the main blocker for true restart-safe batching.
+
+## Current State Table
+
+### Transfer row states
+
+| Transfer state | Meaning | Extra metadata |
+|---|---|---|
+| `pending` | admitted and preparing to start | none |
+| `queued` | blocked from starting | `queue_reason='slot'` or `queue_reason='path'` |
+| `running` | rsync active | `rsync_process_id` set |
+| `completed` | finished successfully | end time set |
+| `failed` | start or runtime failure | error/progress text |
+| `cancelled` | user/system cancelled | end time set |
+
+### Series/anime webhook row states actually used today
+
+| Webhook state | Meaning |
+|---|---|
+| `pending` | received or waiting; also currently reused for manual-sync-required rows |
+| `READY_FOR_TRANSFER` | dry-run passed and awaiting transfer admission |
+| `QUEUED_SLOT` | blocked by global concurrency |
+| `QUEUED_PATH` | blocked by same destination path |
+| `syncing` | transfer active |
+| `completed` | transfer finished |
+| `failed` | transfer/scheduler error |
+| `cancelled` | transfer cancelled |
+
+Supporting manual-sync fields in current use:
+- `requires_manual_sync`
+- `manual_sync_reason`
+- `dry_run_result`
+- `dry_run_performed_at`
+
+## V3 Alignment Status
+
+### Implemented and working
+
+- season-level batching by series/season
+- dry-run validation before sync
+- queue reason separation between slot and path
+- tuple return contract from `start_transfer()`
+- transfer-to-notification linkage by `transfer_id`
+- slot-to-path queue conversion when a path conflict emerges later
+- same-path promotion re-registration before start
+- restart rebuild of running queue reservations
+
+### Partially implemented
+
+- completion marking is designed correctly in the model layer, but the full completion path still needs tightening
+- restart recovery is better for running transfers, but not yet for scheduled batch jobs
+
+### Not yet aligned with the original target
+
+- no real `MANUAL_SYNC_REQUIRED` stored status yet
+- scheduler jobs are not durably persisted/recovered
+- movie webhook lifecycle is not as explicit about queue reasons as series/anime
+
+## Recommended Next Steps
+
+1. persist/recover scheduler jobs using DB-backed batch records or deterministic rebuild from `pending` + `auto_sync_scheduled_at`
+2. normalize manual-sync-required notifications to one explicit terminal status
+3. tighten series/anime completion propagation so only rows that were actually `syncing` become `completed`
+
+## Summary
+
+The current V3 implementation is much closer to the intended design after the queue fixes: queue reasons are now persisted, same-path promotions reclaim in-memory ownership correctly, and running transfers recover their path reservations after restart. The main remaining gaps are durable scheduler recovery, explicit manual-sync-required status, and stricter completion propagation.

--- a/docs/database/LEGACY_V2_MIGRATION_NOTES.md
+++ b/docs/database/LEGACY_V2_MIGRATION_NOTES.md
@@ -1,0 +1,34 @@
+# Legacy V2 Migration Notes
+
+Last updated: 2026-03-19
+
+## Purpose
+
+This page keeps the older v2 migration guidance separate from the live schema reference in `docs/database/v2_schema.md`.
+
+Treat the notes here as legacy migration context, not as current runtime instructions.
+
+## Legacy Migration Assumptions
+
+These notes describe the earlier v1-to-v2 transition model:
+- table renames across webhook and backup tables
+- column renames such as `transfer_type` -> `operation_type`, `process_id` -> `rsync_process_id`, and `backup_dir` -> `backup_path`
+- index name updates to match renamed tables
+
+## Legacy/Destructive Migration Guidance
+
+Historical migration planning assumed data loss could be acceptable for the v2 cutover. That guidance may be destructive and should not be treated as the default for a live installation.
+
+The older flow was:
+- optionally back up the old database
+- drop old tables
+- create the new schema
+- optionally migrate only critical data such as settings and active transfers
+
+If you need that legacy path, review the script and validate it against the current deployment before using it.
+
+## Current References
+
+- Current live schema: `docs/database/v2_schema.md`
+- Migration script reference: `scripts/migrate_v1_to_v2.py`
+- Legacy v1 schema: `docs/database/v1_schema.md`

--- a/docs/database/v2_schema.md
+++ b/docs/database/v2_schema.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines the v2 database schema for DragonCP with improved naming conventions and cleaner structure. This schema will replace v1 in the next release.
+This document describes the current SQLite schema used by DragonCP.
 
 **Database System:** SQLite  
 **Database File:** `dragoncp.db` (stored in project root)  
@@ -10,23 +10,24 @@ This document defines the v2 database schema for DragonCP with improved naming c
 
 ## Schema Changes Summary
 
-### Table Renames
-- `transfers` → `transfers` (keeping plural for consistency with codebase)
-- `webhook_notifications` → `movie_webhook`
-- `series_webhook_notifications` → `series_webhook`
-- `rename_notifications` → `rename_webhook`
-- `transfer_backups` → `backup`
-- `transfer_backup_files` → `backup_file`
-- `app_settings` → `app_settings` (no change)
+### Table Names In Current Code
+- `transfers`
+- `radarr_webhook`
+- `sonarr_webhook`
+- `rename_webhook`
+- `backup`
+- `backup_file`
+- `app_settings`
 
 ### Column Renames
 - `transfer_type` → `operation_type` (more descriptive)
 - `process_id` → `rsync_process_id` (clearer purpose)
 - `backup_dir` → `backup_path` (consistent with other path fields)
 
-### Column Additions/Changes
-- All timestamp fields standardized: `created_at`, `updated_at`, `completed_at`
-- Context fields in `backup_file` kept but better documented
+### Queue-Related Additions/Changes
+- `transfers.queue_reason` stores whether a queued transfer is blocked by `path` or `slot`
+- series/anime manual-sync-required rows currently use `requires_manual_sync` + `manual_sync_reason`
+- timestamp usage is standardized around `created_at`, `updated_at`, and `completed_at`
 
 ---
 
@@ -42,17 +43,16 @@ CREATE TABLE transfers (
     media_type TEXT NOT NULL,
     folder_name TEXT NOT NULL,
     season_name TEXT,
-    episode_name TEXT,
     source_path TEXT NOT NULL,
     dest_path TEXT NOT NULL,
     operation_type TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending',
     progress TEXT DEFAULT '',
+    queue_reason TEXT,
     rsync_process_id INTEGER,
     logs TEXT DEFAULT '[]',
     parsed_title TEXT,
     parsed_season TEXT,
-    parsed_episode TEXT,
     start_time DATETIME,
     end_time DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -66,17 +66,16 @@ CREATE TABLE transfers (
 - `media_type` - Type of media: 'movies', 'tvshows', 'anime'
 - `folder_name` - Name of the media folder
 - `season_name` - Name of the season folder (for series/anime)
-- `episode_name` - Name of the episode file (for series/anime)
 - `source_path` - Source path on remote server
 - `dest_path` - Destination path on local machine
 - `operation_type` - Type of operation: 'folder', 'file', etc. (renamed from `transfer_type`)
-- `status` - Transfer status: 'pending', 'running', 'completed', 'failed', 'cancelled'
+- `status` - Transfer status: 'pending', 'queued', 'running', 'completed', 'failed', 'cancelled'
 - `progress` - Current progress information (text)
+- `queue_reason` - Queue reason for queued transfers: `path`, `slot`, or `NULL`
 - `rsync_process_id` - Process ID of the rsync process (renamed from `process_id`)
 - `logs` - JSON array of log entries
 - `parsed_title` - Parsed title from folder name
 - `parsed_season` - Parsed season number
-- `parsed_episode` - Parsed episode number
 - `start_time` - Transfer start timestamp
 - `end_time` - Transfer end timestamp
 - `created_at` - Record creation timestamp
@@ -92,13 +91,13 @@ CREATE TABLE transfers (
 
 ---
 
-## Table: `movie_webhook`
+## Table: `radarr_webhook`
 
 **Purpose:** Movie webhook notifications from Radarr
 
 **Schema:**
 ```sql
-CREATE TABLE movie_webhook (
+CREATE TABLE radarr_webhook (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     notification_id TEXT UNIQUE NOT NULL,
     title TEXT NOT NULL,
@@ -119,7 +118,7 @@ CREATE TABLE movie_webhook (
     status TEXT NOT NULL DEFAULT 'pending',
     error_message TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    synced_at DATETIME,
+    completed_at DATETIME,
     transfer_id TEXT,
     raw_webhook_data TEXT
 )
@@ -143,30 +142,30 @@ CREATE TABLE movie_webhook (
 - `release_size` - Release size in bytes
 - `tmdb_id` - The Movie Database ID
 - `imdb_id` - Internet Movie Database ID
-- `status` - Notification status: 'pending', 'syncing', 'completed', 'failed'
+- `status` - Notification status: 'pending', 'syncing', 'completed', 'failed', 'cancelled'
 - `error_message` - Error details if failed
 - `created_at` - Record creation timestamp
-- `synced_at` - Timestamp when synced
+- `completed_at` - Timestamp when the notification completed
 - `transfer_id` - Associated transfer ID
 - `raw_webhook_data` - Full webhook JSON payload
 
 **Indexes:**
-- `idx_movie_webhook_notification_id` on `notification_id` - Fast lookup by notification ID
-- `idx_movie_webhook_status` on `status` - Filtering by status
-- `idx_movie_webhook_created_at` on `created_at` - Sorting by creation time
-- `idx_movie_webhook_transfer_id` on `transfer_id` - Lookup by transfer ID
+- `idx_radarr_webhook_notification_id` on `notification_id` - Fast lookup by notification ID
+- `idx_radarr_webhook_status` on `status` - Filtering by status
+- `idx_radarr_webhook_created_at` on `created_at` - Sorting by creation time
+- `idx_radarr_webhook_transfer_id` on `transfer_id` - Lookup by transfer ID
 
 **Model:** `WebhookNotification` in `models/webhook.py`
 
 ---
 
-## Table: `series_webhook`
+## Table: `sonarr_webhook`
 
 **Purpose:** Series/anime webhook notifications from Sonarr
 
 **Schema:**
 ```sql
-CREATE TABLE series_webhook (
+CREATE TABLE sonarr_webhook (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     notification_id TEXT UNIQUE NOT NULL,
     media_type TEXT NOT NULL,  -- 'tvshows' or 'anime'
@@ -196,7 +195,7 @@ CREATE TABLE series_webhook (
     status TEXT NOT NULL DEFAULT 'pending',
     error_message TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    synced_at DATETIME,
+    completed_at DATETIME,
     transfer_id TEXT,
     -- Auto-sync related fields
     requires_manual_sync INTEGER DEFAULT 0,  -- 0=false, 1=true
@@ -230,7 +229,7 @@ CREATE TABLE series_webhook (
 - `episode_count` - Number of episodes in this notification
 - `episodes` - JSON array of episode details
 - `episode_files` - JSON array of episode file details
-- `season_path` - Season-level destination path
+- `season_path` - Season-level source path from Sonarr event; also used to derive destination path
 - `release_title` - Release title from indexer
 - `release_indexer` - Indexer name
 - `release_size` - Release size in bytes
@@ -238,7 +237,7 @@ CREATE TABLE series_webhook (
 - `status` - Notification status (see State Lifecycle below)
 - `error_message` - Error details if failed
 - `created_at` - Record creation timestamp
-- `synced_at` - Timestamp when synced
+- `completed_at` - Timestamp when the notification completed or was marked syncing/completed by current flow
 - `transfer_id` - Associated transfer ID
 - `requires_manual_sync` - Boolean flag (0=false, 1=true)
 - `manual_sync_reason` - Reason why manual sync is required
@@ -247,21 +246,25 @@ CREATE TABLE series_webhook (
 - `dry_run_performed_at` - Timestamp when dry-run was performed
 - `raw_webhook_data` - Full webhook JSON payload
 
-**Status Values (State Lifecycle):**
-- `pending` - Initial state when webhook is received
+**Status Values In Current Code:**
+- `pending` - Initial state and also currently reused for manual-sync-required rows
 - `READY_FOR_TRANSFER` - Dry-run validation passed, ready for transfer
 - `QUEUED_SLOT` - Blocked by max concurrent transfer limit
 - `QUEUED_PATH` - Blocked by same destination path conflict
 - `syncing` - Transfer actively in progress
 - `completed` - Transfer finished successfully
 - `failed` - Transfer failed or error occurred
-- `MANUAL_SYNC_REQUIRED` - Dry-run validation failed, requires manual intervention
 - `cancelled` - User cancelled the transfer
 
+**Manual-sync-required behavior today:**
+- the code does not currently persist `MANUAL_SYNC_REQUIRED` as a status
+- instead it keeps `status='pending'` and sets `requires_manual_sync=1`
+- `manual_sync_reason`, `dry_run_result`, and `dry_run_performed_at` hold the safety decision details
+
 **Indexes:**
-- `idx_series_webhook_notification_id` on `notification_id` - Fast lookup by notification ID
-- `idx_series_webhook_status` on `status` - Filtering by status
-- `idx_series_webhook_transfer_id` on `transfer_id` - Lookup by transfer ID
+- `idx_sonarr_webhook_notification_id` on `notification_id` - Fast lookup by notification ID
+- `idx_sonarr_webhook_status` on `status` - Filtering by status
+- `idx_sonarr_webhook_transfer_id` on `transfer_id` - Lookup by transfer ID
 
 **Model:** `SeriesWebhookNotification` in `models/webhook.py`
 
@@ -355,7 +358,6 @@ CREATE TABLE backup (
     media_type TEXT,
     folder_name TEXT,
     season_name TEXT,
-    episode_name TEXT,
     source_path TEXT NOT NULL,
     dest_path TEXT NOT NULL,
     backup_path TEXT NOT NULL,
@@ -363,7 +365,8 @@ CREATE TABLE backup (
     total_size INTEGER DEFAULT 0,
     status TEXT NOT NULL DEFAULT 'ready',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    restored_at DATETIME
+    restored_at DATETIME,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 )
 ```
 
@@ -374,7 +377,6 @@ CREATE TABLE backup (
 - `media_type` - Type of media: 'movies', 'tvshows', 'anime'
 - `folder_name` - Name of the media folder
 - `season_name` - Name of the season folder (for series/anime)
-- `episode_name` - Name of the episode file (for series/anime)
 - `source_path` - Source path on remote server
 - `dest_path` - Destination path on local machine
 - `backup_path` - Directory where backup files are stored (renamed from `backup_dir`)
@@ -383,6 +385,7 @@ CREATE TABLE backup (
 - `status` - Backup status: 'ready', 'deleted', etc.
 - `created_at` - Record creation timestamp
 - `restored_at` - Timestamp when backup was restored
+- `updated_at` - Last update timestamp
 
 **Indexes:**
 - `idx_backup_transfer_id` on `transfer_id` - Lookup by transfer ID
@@ -461,16 +464,16 @@ All indexes are created with `CREATE INDEX IF NOT EXISTS` to allow safe re-execu
 - `idx_created_at` on `transfers(created_at)` - Time-based queries
 - `idx_dest_status` on `transfers(dest_path, status)` - Duplicate detection
 
-**Movie Webhook Indexes:**
-- `idx_movie_webhook_notification_id` on `movie_webhook(notification_id)` - Primary lookup
-- `idx_movie_webhook_status` on `movie_webhook(status)` - Status filtering
-- `idx_movie_webhook_created_at` on `movie_webhook(created_at)` - Time-based queries
-- `idx_movie_webhook_transfer_id` on `movie_webhook(transfer_id)` - Transfer linking
+**Radarr Webhook Indexes:**
+- `idx_radarr_webhook_notification_id` on `radarr_webhook(notification_id)` - Primary lookup
+- `idx_radarr_webhook_status` on `radarr_webhook(status)` - Status filtering
+- `idx_radarr_webhook_created_at` on `radarr_webhook(created_at)` - Time-based queries
+- `idx_radarr_webhook_transfer_id` on `radarr_webhook(transfer_id)` - Transfer linking
 
-**Series Webhook Indexes:**
-- `idx_series_webhook_notification_id` on `series_webhook(notification_id)` - Primary lookup
-- `idx_series_webhook_status` on `series_webhook(status)` - Status filtering
-- `idx_series_webhook_transfer_id` on `series_webhook(transfer_id)` - Transfer linking
+**Sonarr Webhook Indexes:**
+- `idx_sonarr_webhook_notification_id` on `sonarr_webhook(notification_id)` - Primary lookup
+- `idx_sonarr_webhook_status` on `sonarr_webhook(status)` - Status filtering
+- `idx_sonarr_webhook_transfer_id` on `sonarr_webhook(transfer_id)` - Transfer linking
 
 **Rename Webhook Indexes:**
 - `idx_rename_webhook_notification_id` on `rename_webhook(notification_id)` - Primary lookup
@@ -518,5 +521,3 @@ Since data loss is acceptable for v2, the migration script will:
 - **Webhook Models:** `models/webhook.py`
 - **Settings Model:** `models/settings.py`
 - **Migration Script:** `scripts/migrate_v1_to_v2.py`
-
-

--- a/docs/database/v2_schema.md
+++ b/docs/database/v2_schema.md
@@ -8,7 +8,7 @@ This document describes the current SQLite schema used by DragonCP.
 **Database File:** `dragoncp.db` (stored in project root)  
 **Connection Manager:** `DatabaseManager` in `models/database.py`
 
-## Schema Changes Summary
+## Current Schema Conventions
 
 ### Table Names In Current Code
 - `transfers`
@@ -487,34 +487,18 @@ All indexes are created with `CREATE INDEX IF NOT EXISTS` to allow safe re-execu
 
 ---
 
-## Migration Notes
+## Legacy/Migration Notes
 
-### Breaking Changes
-1. **Table Renames:** All webhook and backup tables have been renamed. Code must be updated to use new table names.
-2. **Column Renames:** 
-   - `transfer_type` → `operation_type`
-   - `process_id` → `rsync_process_id`
-   - `backup_dir` → `backup_path`
-3. **Index Renames:** Index names updated to match new table names.
+Older v1-to-v2 migration guidance, including destructive migration assumptions, has been moved out of this live schema reference.
 
-### Data Migration
-Since data loss is acceptable for v2, the migration script will:
-- Optionally backup the old database
-- Drop all old tables
-- Create new schema with v2 structure
-- Optionally migrate critical data (settings, active transfers) if needed
-
-### Code Updates Required
-- Update all SQL queries in model classes
-- Update table names in all queries
-- Update column names in affected queries
-- Remove old migration methods (`_ensure_*` methods)
+See `docs/database/LEGACY_V2_MIGRATION_NOTES.md` for legacy migration context.
 
 ---
 
 ## Related Documentation
 
 - **v1 Schema:** `docs/database/v1_schema.md`
+- **Legacy migration notes:** `docs/database/LEGACY_V2_MIGRATION_NOTES.md`
 - **Database Manager:** `models/database.py`
 - **Transfer Model:** `models/transfer.py`
 - **Backup Model:** `models/backup.py`

--- a/docs/queue-management/QUEUE_MANAGEMENT_IMPLEMENTATION.md
+++ b/docs/queue-management/QUEUE_MANAGEMENT_IMPLEMENTATION.md
@@ -1,504 +1,206 @@
-# Queue Management System Implementation
+# Queue Management Implementation
 
-**Version**: v1.9.0  
-**Date**: October 31, 2024  
-**Feature**: Advanced Queue Management with Duplicate Detection
+Last updated: 2026-03-19
+Primary files: `services/queue_manager.py`, `services/transfer_coordinator.py`, `services/transfer_service.py`, `models/transfer.py`, `models/database.py`
 
----
+## Purpose
 
-## Overview
+DragonCP uses one shared queue system for manual syncs, movie webhooks, and series/anime syncs.
 
-This document describes the implementation of the new queue management system with STRICT destination path validation for DragonCP. The system prevents duplicate syncs to the same destination and limits concurrent transfers to 3 at a time.
+The queue system enforces two runtime guarantees:
+- only one transfer may write to a normalized destination path at a time
+- only `MAX_CONCURRENT_TRANSFERS` transfers may run at once (`3` today)
 
----
+## Current Queue Model
 
-## Key Features
+### Transfer-level states
 
-### 1. **STRICT Duplicate Destination Validation**
-- **When**: Before any transfer starts (auto-sync or manual)
-- **How**: Checks if an active/running transfer already has the same destination path
-- **Action**: Marks new transfer as `duplicate` status if destination conflict detected
-- **Normalization**: Paths are normalized (absolute, case-insensitive on Windows, trailing slash removed)
-
-### 2. **Queue System (Max 3 Concurrent Transfers)**
-- **Limit**: Maximum 3 transfers can run simultaneously
-- **Queuing**: Additional transfers are marked as `queued` status
-- **Auto-Promotion**: When a transfer completes, the oldest queued transfer is automatically promoted to `pending` and starts
-- **Applies To**: ALL transfers (movies auto-sync, series/anime auto-sync, manual syncs)
-
-### 3. **New Transfer Statuses**
-- **`queued`**: Transfer is waiting for an available slot (< 3 running transfers)
-- **`duplicate`**: Transfer was rejected due to duplicate destination path
-
----
-
-## Architecture
-
-### New Component: QueueManager
-
-**File**: `services/queue_manager.py`
-
-**Responsibilities**:
-- Track active destinations to prevent duplicates
-- Limit concurrent transfers to 3
-- Manage queue of pending transfers
-- Auto-promote queued transfers when slots become available
-
-**Key Methods**:
-- `check_duplicate_destination(dest_path)`: STRICT validation for duplicate paths
-- `register_transfer(transfer_id, dest_path)`: Register and queue/start transfer
-- `unregister_transfer(transfer_id)`: Unregister completed transfer and promote next
-- `get_queue_status()`: Get current queue statistics
-
-### Updated Components
-
-#### 1. TransferCoordinator
-**File**: `services/transfer_coordinator.py`
-
-**Changes**:
-- Initialize QueueManager before starting transfers
-- STRICT duplicate check BEFORE creating transfer record
-- Queue management integration in `start_transfer()`
-- Unregister transfers on completion in `_post_transfer_completion()`
-- New method: `start_queued_transfer()` for promoting queued transfers
-- New method: `get_queue_status()` for queue statistics
-
-#### 2. TransferService
-**File**: `services/transfer_service.py`
-
-**Changes**:
-- Accept `queue_manager` parameter in constructor
-- Enhanced `cancel_transfer()` to handle queued transfers
-
-#### 3. Transfer Routes
-**File**: `routes/transfers.py`
-
-**Changes**:
-- `/api/transfers/active` now returns `queue_status` object
-- New endpoint: `/api/transfers/queue/status` for queue statistics
-
-#### 4. Frontend (Transfer Manager)
-**File**: `static/modules/transfer-manager.js`
-
-**Changes**:
-- `loadActiveTransfers()` now processes queue status
-- New method: `updateQueueStatusDisplay()` to show queue info in badge
-- Badge shows: `"X/3 running, Y queued"` format
-
-#### 5. Frontend (CSS)
-**File**: `static/style.css`
-
-**Changes**:
-- New CSS class: `.transfer-status-queued` (cyan badge)
-- New CSS class: `.transfer-status-duplicate` (orange badge)
-
----
-
-## Flow Diagrams
-
-### Transfer Start Flow with Queue Management
-
-```
-User/Webhook triggers transfer
-        │
-        ▼
-┌───────────────────────────────────────┐
-│ TransferCoordinator.start_transfer()  │
-└───────────────────────────────────────┘
-        │
-        ▼
-┌───────────────────────────────────────┐
-│ STRICT CHECK:                         │
-│ QueueManager.check_duplicate_dest()   │
-└───────────────────────────────────────┘
-        │
-        ├─── Duplicate Found? ────────────> Mark as 'duplicate', Return False
-        │
-        ▼ No Duplicate
-┌───────────────────────────────────────┐
-│ QueueManager.register_transfer()      │
-│ - Check if < 3 transfers running      │
-└───────────────────────────────────────┘
-        │
-        ├─── Queue Full (3 running) ──────> Mark as 'queued', Return True
-        │
-        ▼ Slot Available
-┌───────────────────────────────────────┐
-│ Start Transfer Immediately            │
-│ - Create DB record with 'running'     │
-│ - Start rsync process                 │
-│ - Start monitoring thread             │
-└───────────────────────────────────────┘
-```
-
-### Transfer Completion and Promotion Flow
-
-```
-Transfer completes/fails/cancelled
-        │
-        ▼
-┌───────────────────────────────────────┐
-│ _post_transfer_completion()           │
-│ - Update webhook status               │
-│ - Send Discord notification           │
-│ - Finalize backup                     │
-└───────────────────────────────────────┘
-        │
-        ▼
-┌───────────────────────────────────────┐
-│ QueueManager.unregister_transfer()    │
-│ - Remove from active destinations     │
-│ - Remove from running transfers       │
-└───────────────────────────────────────┘
-        │
-        ▼
-┌───────────────────────────────────────┐
-│ QueueManager._promote_next_queued()   │
-│ - Get oldest queued transfer          │
-│ - Re-check for duplicate destination  │
-│ - Update status to 'pending'          │
-│ - Call coordinator.start_queued()     │
-└───────────────────────────────────────┘
-```
-
----
-
-## Database Schema
-
-### Transfer Status Values
-
-The `transfers` table `status` column now supports these values:
-
-| Status | Description |
-|--------|-------------|
-| `pending` | Transfer is ready to start (initial state) |
-| `running` | Transfer is currently in progress |
-| `queued` | Transfer is waiting for an available slot |
-| `duplicate` | Transfer was rejected due to duplicate destination |
-| `completed` | Transfer finished successfully |
-| `failed` | Transfer encountered an error |
-| `cancelled` | Transfer was cancelled by user |
-
-**Note**: No schema migration required as `status` is TEXT type.
-
----
-
-## API Changes
-
-### Endpoint: `GET /api/transfers/active`
-
-**Response** (new field added):
-```json
-{
-  "status": "success",
-  "transfers": [...],
-  "total": 5,
-  "queue_status": {
-    "max_concurrent": 3,
-    "running_count": 2,
-    "queued_count": 3,
-    "available_slots": 1,
-    "running_transfer_ids": ["transfer1", "transfer2"],
-    "queued_transfer_ids": ["transfer3", "transfer4", "transfer5"],
-    "active_destinations": ["transfer1", "transfer2"]
-  }
-}
-```
-
-### New Endpoint: `GET /api/transfers/queue/status`
-
-**Response**:
-```json
-{
-  "status": "success",
-  "queue": {
-    "max_concurrent": 3,
-    "running_count": 2,
-    "queued_count": 1,
-    "available_slots": 1,
-    "running_transfer_ids": ["transfer1", "transfer2"],
-    "queued_transfer_ids": ["transfer3"],
-    "active_destinations": ["transfer1", "transfer2"]
-  }
-}
-```
-
----
-
-## WebSocket Events
-
-### New Events Emitted by QueueManager
-
-1. **`transfer_duplicate`**
-   - **When**: Duplicate destination detected
-   - **Payload**:
-     ```json
-     {
-       "transfer_id": "movie_123_456",
-       "existing_transfer_id": "movie_123_455",
-       "dest_path": "/mnt/media/Movies/Example (2024)",
-       "message": "Duplicate destination detected"
-     }
-     ```
-
-2. **`transfer_queued`**
-   - **When**: Transfer added to queue (3 already running)
-   - **Payload**:
-     ```json
-     {
-       "transfer_id": "series_789_012",
-       "message": "Transfer added to queue"
-     }
-     ```
-
-3. **`transfer_promoted`**
-   - **When**: Queued transfer promoted to running
-   - **Payload**:
-     ```json
-     {
-       "transfer_id": "series_789_012",
-       "message": "Transfer promoted from queue"
-     }
-     ```
-
----
-
-## Use Cases
-
-### Use Case 1: Series Episode Batch (Your Original Scenario)
-
-**Scenario**: 10 episode notifications received in 10 seconds for the same season
-
-**Behavior**:
-1. **First episode notification** arrives → Auto-sync triggered after 60s wait time
-   - Destination: `/mnt/media/TV Shows/Series Name (2024)/Season 01`
-   - Status: `running` (slot 1/3)
-
-2. **Second episode notification** (2 seconds later) → Auto-sync triggered after 60s wait
-   - **Same destination**: `/mnt/media/TV Shows/Series Name (2024)/Season 01`
-   - **STRICT CHECK**: Duplicate detected!
-   - Status: `duplicate` (not queued, not started)
-   - User sees in UI: Orange badge "duplicate"
-
-3. **Episodes 3-10**: Same as #2, all marked as `duplicate`
-
-**Result**: Only ONE sync runs for the entire season, preventing conflicts and redundant operations.
-
----
-
-### Use Case 2: Multiple Different Transfers
-
-**Scenario**: User triggers 5 different movie syncs manually
-
-**Behavior**:
-1. **Movies 1-3**: Start immediately
-   - Status: `running` (slots 1/3, 2/3, 3/3)
-
-2. **Movies 4-5**: Queue is full
-   - Status: `queued`
-   - User sees in UI: Badge shows "3/3 running, 2 queued"
-
-3. **Movie 1 completes**: 
-   - Movie 4 auto-promoted to `running`
-   - Badge updates: "3/3 running, 1 queued"
-
-4. **Movie 2 completes**:
-   - Movie 5 auto-promoted to `running`
-   - Badge updates: "3/3 running"
-
----
-
-### Use Case 3: Mixed Auto-Sync and Manual Sync
-
-**Scenario**: 2 auto-syncs running, user starts 3 manual syncs
-
-**Behavior**:
-1. **Auto-syncs 1-2**: Running (slots 1/3, 2/3)
-2. **Manual sync 1**: Starts immediately (slot 3/3)
-3. **Manual syncs 2-3**: Queued
-4. **Queue system treats all equally**: Auto-syncs and manual syncs share the same queue
-
----
-
-## Configuration
-
-### Queue Settings
-
-**File**: `services/queue_manager.py`
-
-```python
-class QueueManager:
-    # Maximum number of concurrent transfers allowed
-    MAX_CONCURRENT_TRANSFERS = 3
-```
-
-**To Change**: Modify `MAX_CONCURRENT_TRANSFERS` constant in `QueueManager` class.
-
----
-
-## UI Display
-
-### Active Transfers Badge
-
-**Before**:
-```
-[2 active]
-```
-
-**After** (with queue):
-```
-[2/3 running, 1 queued]
-```
-
-### Transfer Status Badges
-
-| Status | Badge Color | CSS Class |
-|--------|-------------|-----------|
-| Running | Blue | `.transfer-status-running` |
-| Pending | Yellow | `.transfer-status-pending` |
-| **Queued** | **Cyan** | **`.transfer-status-queued`** |
-| **Duplicate** | **Orange** | **`.transfer-status-duplicate`** |
-| Completed | Green | `.transfer-status-completed` |
-| Failed | Red | `.transfer-status-failed` |
-| Cancelled | Gray | `.transfer-status-cancelled` |
-
----
-
-## Testing Scenarios
-
-### Test 1: Duplicate Detection
-1. Start a manual sync for a movie
-2. Immediately start another sync for the SAME movie
-3. **Expected**: Second sync marked as `duplicate`
-
-### Test 2: Queue System
-1. Start 3 different movie syncs quickly
-2. Start a 4th sync
-3. **Expected**: 
-   - First 3 show `running`
-   - 4th shows `queued`
-   - Badge shows "3/3 running, 1 queued"
-
-### Test 3: Auto-Promotion
-1. Have 3 transfers running and 2 queued
-2. Cancel one running transfer
-3. **Expected**: 
-   - First queued transfer auto-promoted to `running`
-   - Badge updates to "3/3 running, 1 queued"
-
-### Test 4: Series Episode Batching
-1. Trigger 10 episode notifications for same season within 10 seconds
-2. **Expected**:
-   - First one goes through auto-sync
-   - Remaining 9 marked as `duplicate`
-   - Only ONE actual rsync runs
-
----
-
-## Limitations and Edge Cases
-
-### Handled Edge Cases
-
-1. **App Restart During Queue**: 
-   - `force_unregister_stale_transfers()` cleans up stale tracking on startup
-   
-2. **Path Normalization**: 
-   - Windows paths are case-insensitive
-   - Trailing slashes removed
-   - Relative paths converted to absolute
-
-3. **Cancelled Queued Transfers**: 
-   - Can cancel queued transfers before they start
-   - Status updated to `cancelled`
-
-### Known Limitations
-
-1. **Queue Persistence**: Queue is in-memory, not persisted to database
-   - On app restart, queued transfers revert to `pending` status
-   
-2. **Queue Order**: FIFO (First In, First Out) based on `created_at` timestamp
-   - No priority system for transfers
-
-3. **Destination Comparison**: Based on destination path string only
-   - Doesn't check if files are identical (relies on rsync)
-
----
-
-## Troubleshooting
-
-### Issue: Transfers stuck in "queued" status
-
-**Cause**: Running transfers may have crashed without cleanup
-
-**Solution**:
-1. Restart the app (cleanup runs on startup)
-2. Or manually cancel stuck transfers
-
-### Issue: False duplicate detection
-
-**Cause**: Path normalization differences
-
-**Debug**:
-```python
-# Check normalized paths in logs
-print(f"Normalized: {queue_manager._normalize_path(dest_path)}")
-```
-
-### Issue: Too many transfers queued
-
-**Cause**: High incoming webhook rate
-
-**Solution**: Increase `MAX_CONCURRENT_TRANSFERS` in `queue_manager.py`
-
----
-
-## Future Enhancements
-
-1. **Priority Queue**: Add priority levels for transfers
-2. **Configurable Max Concurrent**: Make `MAX_CONCURRENT_TRANSFERS` a UI setting
-3. **Queue Persistence**: Store queue state in database
-4. **Smart Batching**: Auto-merge queued transfers with same source/dest
-5. **Bandwidth Management**: Dynamic queue size based on available bandwidth
-
----
-
-## Summary of Changes
-
-### New Files
-- `services/queue_manager.py` - Queue management service
-
-### Modified Files
-- `services/transfer_coordinator.py` - Queue integration
-- `services/transfer_service.py` - Queue-aware transfer handling
-- `routes/transfers.py` - Queue status API endpoints
-- `static/modules/transfer-manager.js` - Queue UI display
-- `static/style.css` - New status badge styles
-- `templates/index.html` - Version bump to v1.9.0
-
-### Database
-- No schema changes required (status is TEXT type)
-- New status values: `queued`, `duplicate`
-
----
-
-## Rollback Instructions
-
-If issues arise, to rollback:
-
-1. **Remove Queue Manager**:
-   - Delete `services/queue_manager.py`
-   
-2. **Revert TransferCoordinator**:
-   - Remove `QueueManager` import and initialization
-   - Revert `start_transfer()` to directly start transfers
-   
-3. **Revert Version**:
-   - Change `v1.9.0` back to `v1.8.5` in `templates/index.html`
-
----
-
-## Version History
-
-- **v1.9.0** (Oct 31, 2024): Queue management with duplicate detection
-- **v1.8.5** (Previous): Series/anime auto-sync with dry-run validation
+Transfer rows in `transfers` use these statuses:
+- `pending`: admitted and preparing to start
+- `queued`: not allowed to start yet
+- `running`: rsync process active
+- `completed`
+- `failed`
+- `cancelled`
 
+Queued transfer rows use `queue_reason` for the blocking reason:
+- `path`: same destination path already reserved by another transfer
+- `slot`: concurrency cap reached
+
+`queue_reason` is persisted in the `transfers` table and is now added automatically for older databases during startup.
+
+### Webhook-level states
+
+Series/anime webhook rows in `sonarr_webhook` expose the queue reason more explicitly:
+- `READY_FOR_TRANSFER`
+- `QUEUED_SLOT`
+- `QUEUED_PATH`
+- `syncing`
+- `completed`
+- `failed`
+- `cancelled`
+
+Movie webhook rows do not currently expose queue-reason-specific states; they still share the same transfer queue internally.
+
+## In-Memory Queue State
+
+`QueueManager` maintains two process-local maps:
+- `active_destinations`: `{normalized_dest_path: transfer_id}`
+- `running_transfers`: `{transfer_id: normalized_dest_path}`
+
+These maps are the live path-lock and running-slot authority used during admission and promotion.
+
+## Admission Flow
+
+All new transfers converge through `TransferCoordinator.start_transfer()`.
+
+### 1. Path-conflict check
+
+`QueueManager.check_duplicate_destination()` checks whether the normalized destination path is already reserved.
+
+If the path is already owned:
+- the new transfer row is created with `status='queued'`
+- `queue_reason='path'`
+- the transfer returns as `QUEUED_PATH`
+- for series/anime, linked webhook notifications are updated to `QUEUED_PATH`
+
+### 2. Slot-cap check
+
+If the path is free, `QueueManager.register_transfer()` decides whether the transfer can run immediately.
+
+If all slots are full:
+- the new transfer row is created with `status='queued'`
+- `queue_reason='slot'`
+- the destination is still reserved in `active_destinations`
+- the transfer returns as `QUEUED_SLOT`
+
+That destination reservation is intentional: it prevents later transfers for the same path from being admitted ahead of the already-queued owner.
+
+### 3. Immediate start
+
+If both the path and slot checks pass:
+- the transfer is registered in `active_destinations` and `running_transfers`
+- the transfer row is created with `status='pending'`
+- `TransferService.start_rsync_process()` starts rsync and then updates the row to `running`
+
+## Promotion Flow
+
+Promotion happens from `QueueManager.unregister_transfer()` after a running transfer finishes, fails, or is cancelled.
+
+Promotion order is always:
+1. same-path queue first
+2. general slot queue second
+
+### Path-specific promotion
+
+`_promote_same_path_queued(dest_path)`:
+- looks for queued transfer rows whose normalized `dest_path` matches the freed path
+- prefers transfers that are explicitly or implicitly path-queued
+- re-checks the path lock for safety
+- re-registers the promoted transfer in `active_destinations` and `running_transfers`
+- updates the transfer to `pending`
+- updates linked series/anime webhook rows to `READY_FOR_TRANSFER`
+- starts it through `TransferCoordinator.start_queued_transfer()`
+
+This re-registration step is the fix for issue `#40`: a same-path promoted transfer must reclaim in-memory queue ownership before rsync starts, otherwise a later transfer can incorrectly see the path as free.
+
+### General slot promotion
+
+`_promote_next_queued_transfer()`:
+- scans queued transfer rows oldest-first
+- determines queue type from `queue_reason` first, then falls back to `progress` parsing for legacy rows
+- re-checks path ownership before promotion
+
+If a queued slot transfer now conflicts with a running transfer on the same destination:
+- it is converted from `queue_reason='slot'` to `queue_reason='path'`
+- its `progress` text is updated
+- linked series/anime webhooks move from `QUEUED_SLOT` to `QUEUED_PATH`
+- it stays queued until the same path is freed
+
+If a queued transfer is promotable:
+- queue state is reserved before start
+- the transfer is started through `start_queued_transfer()`
+
+## Defensive Start Guard
+
+`TransferCoordinator.start_queued_transfer()` now verifies that the promoted transfer is already represented in queue-manager running state before it starts rsync.
+
+This prevents untracked queued promotions from bypassing path ownership rules.
+
+## Startup and Restart Recovery
+
+Queue state is process-local, so startup now rebuilds it from the database.
+
+Current startup flow:
+1. `QueueManager.force_unregister_stale_transfers()` removes stale in-memory entries
+2. the same method rebuilds running reservations from DB rows with `status='running'`
+3. `TransferService.resume_active_transfers()` resumes monitoring for live rsync PIDs
+4. `TransferCoordinator` restarts post-completion watchers for resumed transfers so queue release, webhook status updates, Discord notifications, and backup finalization still happen
+
+This recovery closes the gap where a restarted app could have running rsync processes but no in-memory path reservations.
+
+## Queue Reason Behavior
+
+### Current behavior
+
+- `queue_reason` is stored on transfer creation for both path and slot queues
+- it is updated when slot-queued work is reclassified as path-queued
+- queue promotion logic uses `queue_reason` as the primary classifier
+- progress-text parsing remains only as backward-compatible fallback for pre-column or legacy rows
+
+### Why this matters
+
+Without a persisted `queue_reason`, queue logic has to infer intent from human-readable `progress` text, which is fragile and can misclassify queued work.
+
+## Current API Notes
+
+Queue status is exposed through:
+- `GET /api/transfers/active`
+- `GET /api/transfers/queue/status`
+
+Returned fields:
+- `max_concurrent`
+- `running_count`
+- `queued_count`
+- `available_slots`
+- `running_transfer_ids`
+- `queued_transfer_ids`
+- `active_destinations`
+
+Implementation note: `active_destinations` currently returns the transfer IDs that own reserved destinations, not the normalized path strings themselves.
+
+## Current Series/Anime Queue Lifecycle
+
+For series/anime auto-sync:
+1. webhook rows batch in `pending`
+2. dry-run success moves them to `READY_FOR_TRANSFER`
+3. transfer admission returns one of:
+   - `running`
+   - `QUEUED_SLOT`
+   - `QUEUED_PATH`
+4. linked webhook rows follow that result
+5. on promotion, queued webhook rows move to `syncing`
+6. on transfer completion, linked webhook rows are finalized
+
+## Known Gaps
+
+These are not queue-breakers, but they still matter operationally:
+- movie webhook rows do not currently expose queue reason or queued status as clearly as series/anime rows
+- auto-sync batch jobs are still in-memory only and do not survive restart
+- manual-sync-required behavior still uses `pending + requires_manual_sync` instead of one explicit terminal status
+- completion marking for series/anime is safer than before, but the broader completion path should still be tightened to guarantee that only truly synced rows move to `completed`
+
+## Files Most Relevant To Queue Behavior
+
+- `services/queue_manager.py`
+- `services/transfer_coordinator.py`
+- `services/transfer_service.py`
+- `services/webhook_service.py`
+- `services/auto_sync_scheduler.py`
+- `models/transfer.py`
+- `models/database.py`
+- `models/webhook.py`
+
+## Summary
+
+The queue system now correctly preserves same-path ownership across promotion, persists queue intent through `queue_reason`, and rebuilds live running reservations after restart. The remaining work is mostly around queue visibility and lifecycle consistency for scheduler persistence, movie webhook queue states, and manual-sync status normalization.

--- a/docs/queue-management/QUEUE_MANAGEMENT_IMPLEMENTATION.md
+++ b/docs/queue-management/QUEUE_MANAGEMENT_IMPLEMENTATION.md
@@ -50,6 +50,65 @@ Movie webhook rows do not currently expose queue-reason-specific states; they st
 
 These maps are the live path-lock and running-slot authority used during admission and promotion.
 
+## Flow Diagrams
+
+### High-level admission flow
+
+```mermaid
+flowchart TD
+    A[New sync request] --> B[TransferCoordinator.start_transfer]
+    B --> C{Destination path already reserved?}
+    C -->|Yes| D[Create queued transfer]
+    D --> E[queue_reason = path]
+    E --> F[Return QUEUED_PATH]
+    C -->|No| G{Free running slot available?}
+    G -->|No| H[Create queued transfer]
+    H --> I[queue_reason = slot]
+    I --> J[Reserve destination in active_destinations]
+    J --> K[Return QUEUED_SLOT]
+    G -->|Yes| L[Register in running_transfers and active_destinations]
+    L --> M[Create pending transfer]
+    M --> N[Start rsync]
+    N --> O[Transfer becomes running]
+```
+
+### Queue promotion flow
+
+```mermaid
+flowchart TD
+    A[Running transfer finishes] --> B[QueueManager.unregister_transfer]
+    B --> C[Free running_transfers entry]
+    C --> D[Free active_destinations path lock]
+    D --> E[Try same-path promotion first]
+    E --> F{Queued transfer for same normalized path?}
+    F -->|Yes| G[Re-register promoted transfer in memory]
+    G --> H[Hand off to start_queued_transfer]
+    H --> I[queued -> pending]
+    I --> J[Webhook state -> syncing]
+    J --> K[Start rsync]
+    F -->|No| L[Scan general queued transfers]
+    L --> M{Path still free and slot available?}
+    M -->|Yes| N[Reserve queue state in memory]
+    N --> H
+    M -->|No, path conflict| O[Convert slot queue to path queue if needed]
+    O --> P[Keep queued until matching path frees]
+    M -->|No, no slot| Q[Stay queued]
+```
+
+### Restart recovery flow
+
+```mermaid
+flowchart TD
+    A[App start] --> B[force_unregister_stale_transfers]
+    B --> C[Clear stale in-memory reservations]
+    C --> D[Restore running transfers from DB]
+    D --> E[Restore queued destination reservations from DB]
+    E --> F[Promote queued work into free slots]
+    F --> G[resume_active_transfers]
+    G --> H[Resume monitoring live rsync PIDs]
+    H --> I[Restart post-completion watchers]
+```
+
 ## Admission Flow
 
 All new transfers converge through `TransferCoordinator.start_transfer()`.

--- a/docs/queue-management/QUEUE_MANAGEMENT_IMPLEMENTATION.md
+++ b/docs/queue-management/QUEUE_MANAGEMENT_IMPLEMENTATION.md
@@ -98,9 +98,9 @@ Promotion order is always:
 - prefers transfers that are explicitly or implicitly path-queued
 - re-checks the path lock for safety
 - re-registers the promoted transfer in `active_destinations` and `running_transfers`
-- updates the transfer to `pending`
-- updates linked series/anime webhook rows to `READY_FOR_TRANSFER`
-- starts it through `TransferCoordinator.start_queued_transfer()`
+- hands it off to `TransferCoordinator.start_queued_transfer()`
+
+`start_queued_transfer()` then performs the visible state transitions (`queued` -> `pending` and `QUEUED_*` -> `syncing`) only after queue ownership has been confirmed.
 
 This re-registration step is the fix for issue `#40`: a same-path promoted transfer must reclaim in-memory queue ownership before rsync starts, otherwise a later transfer can incorrectly see the path as free.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.1.0",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.1.0",
+      "version": "2.1.3",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
         "@fontsource-variable/nunito-sans": "^5.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/layout/app-layout.tsx
+++ b/frontend/src/components/layout/app-layout.tsx
@@ -32,7 +32,7 @@ interface AppLayoutProps {
 }
 
 // App version - can be made configurable from env or API later
-const APP_VERSION = 'v2.0.8';
+const APP_VERSION = 'v2.1.3';
 
 // Dragon-CP Logo URL
 const LOGO_URL = 'https://blog.infinitysystems.in/dragondbserver/DragonDB_Trans.png';

--- a/models/database.py
+++ b/models/database.py
@@ -56,6 +56,7 @@ class DatabaseManager:
                     operation_type TEXT NOT NULL,
                     status TEXT NOT NULL DEFAULT 'pending',
                     progress TEXT DEFAULT '',
+                    queue_reason TEXT,
                     rsync_process_id INTEGER,
                     logs TEXT DEFAULT '[]',
                     parsed_title TEXT,

--- a/models/database.py
+++ b/models/database.py
@@ -25,7 +25,19 @@ class DatabaseManager:
         self.db_path = os.path.join(script_dir, db_path)
         print(f"🗄️  Database path: {self.db_path}")
         self.init_database()
-    
+
+    def _ensure_column(self, conn, table_name: str, column_name: str, column_sql: str):
+        """Add a missing column to an existing table."""
+        existing_columns = {
+            row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+        }
+
+        if column_name in existing_columns:
+            return
+
+        conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_sql}")
+        print(f"🧩 Added missing column {table_name}.{column_name}")
+
     def init_database(self):
         """Initialize database and create tables"""
         with sqlite3.connect(self.db_path) as conn:
@@ -244,7 +256,10 @@ class DatabaseManager:
             conn.execute('CREATE INDEX IF NOT EXISTS idx_backup_transfer_id ON backup(transfer_id)')
             conn.execute('CREATE INDEX IF NOT EXISTS idx_backup_file_backup_id ON backup_file(backup_id)')
             conn.execute('CREATE INDEX IF NOT EXISTS idx_backup_file_context_key ON backup_file(context_key)')
-            
+
+            # Backward-compatible schema additions
+            self._ensure_column(conn, 'transfers', 'queue_reason', "TEXT")
+
             conn.commit()
         
         print(f"✅ Database initialized: {self.db_path}")

--- a/models/transfer.py
+++ b/models/transfer.py
@@ -40,9 +40,9 @@ class Transfer:
                 cursor = conn.execute('''
                     INSERT INTO transfers (
                         transfer_id, media_type, folder_name, season_name,
-                        source_path, dest_path, operation_type, status, rsync_process_id,
-                        parsed_title, parsed_season, start_time
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        source_path, dest_path, operation_type, status, progress,
+                        queue_reason, rsync_process_id, parsed_title, parsed_season, start_time
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ''', (
                     transfer_data['transfer_id'],
                     transfer_data['media_type'],
@@ -52,10 +52,12 @@ class Transfer:
                     transfer_data['dest_path'],
                     transfer_data['operation_type'],
                     transfer_data.get('status', 'pending'),
+                    transfer_data.get('progress', ''),
+                    transfer_data.get('queue_reason'),
                     transfer_data.get('rsync_process_id'),
                     parsed_data['title'],
                     parsed_data['season'],
-                    datetime.now().isoformat()
+                    transfer_data.get('start_time', datetime.now().isoformat())
                 ))
                 conn.commit()
                 print(f"✅ Transfer record created successfully for {transfer_data['transfer_id']}")
@@ -400,4 +402,3 @@ class Transfer:
                 'type': 'unknown',
                 'seasons': []
             }
-

--- a/services/queue_manager.py
+++ b/services/queue_manager.py
@@ -107,8 +107,56 @@ class QueueManager:
         can_start = running_count < self.MAX_CONCURRENT_TRANSFERS
         
         print(f"📊 Queue status: {running_count}/{self.MAX_CONCURRENT_TRANSFERS} running, can_start={can_start}")
-        
+
         return can_start
+
+    def _is_path_queue_transfer(self, transfer: Dict) -> bool:
+        """Determine whether a queued transfer is waiting on a destination-path conflict."""
+        queue_reason = (transfer.get('queue_reason') or '').lower()
+        if queue_reason:
+            return queue_reason == 'path'
+
+        progress_msg = (transfer.get('progress') or '').lower()
+        return (
+            'same destination' in progress_msg or
+            'same path' in progress_msg or
+            ('waiting for' in progress_msg and 'complete' in progress_msg)
+        )
+
+    def _register_running_transfer_internal(self, transfer_id: str, dest_path: str,
+                                            enforce_capacity: bool = True) -> Tuple[bool, str]:
+        """Reserve a destination and register a transfer as running (lock must be held)."""
+        normalized_dest = self._normalize_path(dest_path)
+        existing_transfer_id = self.active_destinations.get(normalized_dest)
+
+        if existing_transfer_id and existing_transfer_id != transfer_id:
+            return (False, 'duplicate')
+
+        existing_dest = self.running_transfers.get(transfer_id)
+        if existing_dest == normalized_dest:
+            self.active_destinations[normalized_dest] = transfer_id
+            return (True, 'running')
+
+        if enforce_capacity and transfer_id not in self.running_transfers and not self.can_start_transfer():
+            return (False, 'capacity')
+
+        if existing_dest and existing_dest in self.active_destinations:
+            if self.active_destinations[existing_dest] == transfer_id:
+                del self.active_destinations[existing_dest]
+
+        self.active_destinations[normalized_dest] = transfer_id
+        self.running_transfers[transfer_id] = normalized_dest
+        return (True, 'running')
+
+    def ensure_running_transfer_registered(self, transfer_id: str, dest_path: str,
+                                           enforce_capacity: bool = True) -> Tuple[bool, str]:
+        """Ensure a transfer is represented in in-memory running state before rsync starts."""
+        with self.lock:
+            return self._register_running_transfer_internal(
+                transfer_id,
+                dest_path,
+                enforce_capacity=enforce_capacity
+            )
     
     def register_transfer(self, transfer_id: str, dest_path: str) -> Tuple[bool, str]:
         """
@@ -129,11 +177,17 @@ class QueueManager:
             
             # Check if we can start immediately or need to queue
             if self.can_start_transfer():
-                # Register as running
-                self.active_destinations[normalized_dest] = transfer_id
-                self.running_transfers[transfer_id] = normalized_dest
-                print(f"✅ Transfer {transfer_id} registered as RUNNING -> {dest_path}")
-                return (True, 'running')
+                registered, status = self._register_running_transfer_internal(
+                    transfer_id,
+                    dest_path,
+                    enforce_capacity=False
+                )
+                if registered:
+                    print(f"✅ Transfer {transfer_id} registered as RUNNING -> {dest_path}")
+                    return (True, status)
+
+                print(f"⚠️  Failed to register transfer {transfer_id} as running: {status}")
+                return (False, status)
             else:
                 # Transfer should be queued
                 # IMPORTANT: Still reserve the destination to prevent duplicate queued transfers
@@ -215,8 +269,13 @@ class QueueManager:
             if t['status'] == 'queued' and self._normalize_path(t.get('dest_path', '')) == self._normalize_path(dest_path)
         ]
         
-        # Sort by creation time (oldest first)
-        queued_path_transfers.sort(key=lambda t: t.get('created_at', t.get('start_time', '')))
+        # Prefer explicit/fallback path-queue entries first, then oldest first.
+        queued_path_transfers.sort(
+            key=lambda t: (
+                0 if self._is_path_queue_transfer(t) else 1,
+                t.get('created_at', t.get('start_time', ''))
+            )
+        )
         
         if not queued_path_transfers:
             print(f"✅ No QUEUED_PATH transfers found for {dest_path}")
@@ -231,7 +290,16 @@ class QueueManager:
         if is_duplicate:
             print(f"⚠️  Path {dest_path} still has active transfer {existing_transfer_id}, cannot promote yet")
             return
-        
+
+        registered, register_status = self._register_running_transfer_internal(
+            transfer_id,
+            dest_path,
+            enforce_capacity=True
+        )
+        if not registered:
+            print(f"⚠️  Could not reserve queue state for promoted path transfer {transfer_id}: {register_status}")
+            return
+
         print(f"🎉 PROMOTING QUEUED_PATH: Transfer {transfer_id} for path {dest_path}")
         
         # Update transfer status from 'queued' to 'pending'
@@ -295,20 +363,7 @@ class QueueManager:
         for queued_transfer in queued_transfers:
             transfer_id = queued_transfer['transfer_id']
             dest_path = queued_transfer['dest_path']
-            queue_reason = queued_transfer.get('queue_reason', '')
-            progress_msg = queued_transfer.get('progress', '')
-            
-            # Determine if this is a path-specific queue or slot queue
-            # First check explicit queue_reason field (added for reliability)
-            if queue_reason:
-                is_path_queue = (queue_reason == 'path')
-            else:
-                # Fallback to progress message parsing (for legacy transfers)
-                is_path_queue = (
-                    'same destination' in progress_msg.lower() or
-                    'same path' in progress_msg.lower() or
-                    ('waiting for' in progress_msg.lower() and 'complete' in progress_msg.lower())
-                )
+            is_path_queue = self._is_path_queue_transfer(queued_transfer)
             
             # Re-check for duplicate destination (using internal method since we hold the lock)
             is_duplicate, existing_transfer_id = self._check_duplicate_destination_internal(dest_path, transfer_id)
@@ -356,10 +411,15 @@ class QueueManager:
                     continue
             
             # Promote this transfer
-            normalized_dest = self._normalize_path(dest_path)
-            self.active_destinations[normalized_dest] = transfer_id
-            self.running_transfers[transfer_id] = normalized_dest
-            
+            registered, register_status = self._register_running_transfer_internal(
+                transfer_id,
+                dest_path,
+                enforce_capacity=True
+            )
+            if not registered:
+                print(f"⚠️  Could not reserve queue state for promoted transfer {transfer_id}: {register_status}")
+                continue
+
             print(f"🎉 PROMOTED: Transfer {transfer_id} from queue")
             print(f"📊 Queue status: {len(self.running_transfers)}/{self.MAX_CONCURRENT_TRANSFERS} running")
             
@@ -412,16 +472,19 @@ class QueueManager:
     
     def force_unregister_stale_transfers(self):
         """
-        Cleanup method to remove stale entries from tracking
-        Should be called on app startup or periodically
+        Cleanup method to remove stale entries from tracking and rebuild running state.
+        Should be called on app startup or periodically.
         """
         with self.lock:
             all_transfers = self.transfer_model.get_all()
-            
+            running_records = [
+                t for t in all_transfers
+                if t['status'] == 'running'
+            ]
+
             # Build set of actually running transfer IDs
             actually_running = {
-                t['transfer_id'] for t in all_transfers 
-                if t['status'] == 'running'
+                t['transfer_id'] for t in running_records
             }
             
             # Remove any tracked transfers that are not actually running
@@ -439,8 +502,28 @@ class QueueManager:
                         del self.active_destinations[dest_path]
                 
                 print(f"🧹 Cleaned up stale transfer tracking: {transfer_id}")
-            
+
+            restored_count = 0
+            for transfer in running_records:
+                transfer_id = transfer['transfer_id']
+                dest_path = transfer.get('dest_path')
+                if not dest_path:
+                    continue
+
+                registered, status = self._register_running_transfer_internal(
+                    transfer_id,
+                    dest_path,
+                    enforce_capacity=False
+                )
+                if registered:
+                    restored_count += 1
+                else:
+                    print(f"⚠️  Could not restore running transfer {transfer_id}: {status}")
+
             if stale_transfers:
                 print(f"✅ Removed {len(stale_transfers)} stale transfer entries")
                 # Try to promote queued transfers after cleanup
                 self._promote_next_queued_transfer()
+
+            if restored_count:
+                print(f"🔄 Restored {restored_count} running transfer reservation(s) from database")

--- a/services/queue_manager.py
+++ b/services/queue_manager.py
@@ -374,6 +374,13 @@ class QueueManager:
             transfer_id = queued_transfer['transfer_id']
             dest_path = queued_transfer['dest_path']
             is_path_queue = self._is_path_queue_transfer(queued_transfer)
+
+            # A transfer may still be DB-queued for a brief window after a prior
+            # promotion already reserved it in memory and handed it off.
+            # Skip it here so we do not start the same queued transfer twice.
+            if transfer_id in self.running_transfers:
+                print(f"⏭️  Skipping already-promoted transfer {transfer_id} during queue scan")
+                continue
             
             # Re-check for duplicate destination (using internal method since we hold the lock)
             is_duplicate, existing_transfer_id = self._check_duplicate_destination_internal(dest_path, transfer_id)

--- a/services/queue_manager.py
+++ b/services/queue_manager.py
@@ -157,6 +157,27 @@ class QueueManager:
                 dest_path,
                 enforce_capacity=enforce_capacity
             )
+
+    def _restore_queued_reservations_internal(self, queued_records: List[Dict]) -> int:
+        """Restore one queued reservation per destination path (lock must be held)."""
+        restored_count = 0
+
+        queued_records.sort(key=lambda t: t.get('created_at', t.get('start_time', '')))
+
+        for transfer in queued_records:
+            transfer_id = transfer['transfer_id']
+            dest_path = transfer.get('dest_path')
+            if not dest_path:
+                continue
+
+            normalized_dest = self._normalize_path(dest_path)
+            if normalized_dest in self.active_destinations:
+                continue
+
+            self.active_destinations[normalized_dest] = transfer_id
+            restored_count += 1
+
+        return restored_count
     
     def register_transfer(self, transfer_id: str, dest_path: str) -> Tuple[bool, str]:
         """
@@ -246,13 +267,14 @@ class QueueManager:
         Internal method to promote QUEUED_PATH transfers for a specific destination path
         
         This is called when a transfer for a specific path completes. It looks for
-        webhook notifications in QUEUED_PATH state waiting for this exact path,
-        and promotes ONE of them (oldest first) back to READY_FOR_TRANSFER for re-validation.
+        queued transfers waiting for this exact path, and promotes ONE of them
+        (oldest first) directly into the normal queued-transfer start flow.
         
         Args:
             dest_path: The destination path that just became available
         """
         if not self.coordinator:
+            print(f"⏸️  Cannot promote same-path queued transfers for {dest_path} without coordinator")
             return
         
         # Check if we have capacity for another transfer
@@ -302,22 +324,6 @@ class QueueManager:
 
         print(f"🎉 PROMOTING QUEUED_PATH: Transfer {transfer_id} for path {dest_path}")
         
-        # Update transfer status from 'queued' to 'pending'
-        self.transfer_model.update(transfer_id, {
-            'status': 'pending',
-            'progress': 'Promoted from path queue, validating...'
-        })
-        
-        # Update associated webhook notification status from QUEUED_PATH to READY_FOR_TRANSFER
-        if self.coordinator and self.coordinator.series_webhook_model:
-            # Update ALL webhook notifications linked to this transfer_id
-            updated = self.coordinator.series_webhook_model.update_notifications_by_transfer_id(
-                transfer_id,
-                {'status': 'READY_FOR_TRANSFER'}
-            )
-            if updated:
-                print(f"📋 Updated {updated} webhook notification(s) to READY_FOR_TRANSFER")
-        
         # Emit WebSocket event if available
         if self.socketio:
             self.socketio.emit('transfer_promoted', {
@@ -342,6 +348,10 @@ class QueueManager:
         This promotes transfers in QUEUED_SLOT state (waiting for any slot to free up).
         It's called after path-specific promotion to fill remaining capacity.
         """
+        if not self.coordinator:
+            print("⏸️  Cannot promote queued transfers without coordinator")
+            return
+
         # Check if we have capacity
         if len(self.running_transfers) >= self.MAX_CONCURRENT_TRANSFERS:
             return
@@ -472,7 +482,7 @@ class QueueManager:
     
     def force_unregister_stale_transfers(self):
         """
-        Cleanup method to remove stale entries from tracking and rebuild running state.
+        Cleanup method to remove stale entries from tracking and rebuild queue state.
         Should be called on app startup or periodically.
         """
         with self.lock:
@@ -480,6 +490,10 @@ class QueueManager:
             running_records = [
                 t for t in all_transfers
                 if t['status'] == 'running'
+            ]
+            queued_records = [
+                t for t in all_transfers
+                if t['status'] == 'queued'
             ]
 
             # Build set of actually running transfer IDs
@@ -495,13 +509,12 @@ class QueueManager:
             
             for transfer_id in stale_transfers:
                 dest_path = self.running_transfers[transfer_id]
-                del self.running_transfers[transfer_id]
-                
-                if dest_path in self.active_destinations:
-                    if self.active_destinations[dest_path] == transfer_id:
-                        del self.active_destinations[dest_path]
-                
                 print(f"🧹 Cleaned up stale transfer tracking: {transfer_id}")
+
+            # Rebuild queue state from database so restart recovery preserves
+            # running reservations and queued destination ownership.
+            self.running_transfers = {}
+            self.active_destinations = {}
 
             restored_count = 0
             for transfer in running_records:
@@ -520,10 +533,19 @@ class QueueManager:
                 else:
                     print(f"⚠️  Could not restore running transfer {transfer_id}: {status}")
 
+            restored_queued_count = self._restore_queued_reservations_internal(queued_records)
+
             if stale_transfers:
                 print(f"✅ Removed {len(stale_transfers)} stale transfer entries")
-                # Try to promote queued transfers after cleanup
-                self._promote_next_queued_transfer()
 
             if restored_count:
                 print(f"🔄 Restored {restored_count} running transfer reservation(s) from database")
+
+            if restored_queued_count:
+                print(f"🧾 Restored {restored_queued_count} queued destination reservation(s) from database")
+
+            while self.coordinator and len(self.running_transfers) < self.MAX_CONCURRENT_TRANSFERS:
+                running_before = len(self.running_transfers)
+                self._promote_next_queued_transfer()
+                if len(self.running_transfers) == running_before:
+                    break

--- a/services/transfer_coordinator.py
+++ b/services/transfer_coordinator.py
@@ -63,7 +63,16 @@ class TransferCoordinator:
         self.queue_manager.force_unregister_stale_transfers()
         
         # Resume any transfers that were running when the app was stopped
-        self.transfer_service.resume_active_transfers()
+        resumed_transfer_ids = self.transfer_service.resume_active_transfers()
+
+        if resumed_transfer_ids:
+            import threading
+            for transfer_id in resumed_transfer_ids:
+                threading.Thread(
+                    target=self._post_transfer_completion,
+                    args=(transfer_id,),
+                    daemon=True
+                ).start()
     
     # Transfer Operations
     def start_transfer(self, transfer_id: str, source_path: str, dest_path: str, 
@@ -293,7 +302,15 @@ class TransferCoordinator:
         transfer = self.transfer_model.get(transfer_id)
         if not transfer:
             return False
-        
+
+        registered, register_status = self.queue_manager.ensure_running_transfer_registered(
+            transfer_id,
+            transfer['dest_path']
+        )
+        if not registered:
+            print(f"⚠️  Cannot start queued transfer {transfer_id}: queue state not ready ({register_status})")
+            return False
+
         # Update status from 'queued' to 'pending' before starting
         # (start_rsync_process will update it to 'running')
         self.transfer_model.update(transfer_id, {
@@ -610,4 +627,3 @@ class TransferCoordinator:
             return bool(re.match(url_pattern, url))
         except Exception:
             return False
-

--- a/services/transfer_service.py
+++ b/services/transfer_service.py
@@ -653,9 +653,16 @@ class TransferService:
             process = psutil.Process(transfer['rsync_process_id'])
             
             # Monitor the process until completion
-            process.wait()
-            return_code = process.returncode
-            
+            return_code = process.wait()
+
+            if return_code is None:
+                self.transfer_model.update(transfer_id, {
+                    'status': 'completed',
+                    'progress': 'Transfer finished after restart (exit status unavailable)',
+                    'end_time': datetime.now().isoformat()
+                })
+                return
+
             if return_code == 0:
                 self.transfer_model.update(transfer_id, {
                     'status': 'completed',
@@ -668,11 +675,18 @@ class TransferService:
                     'progress': f'Transfer failed with exit code: {return_code}',
                     'end_time': datetime.now().isoformat()
                 })
-                
-        except Exception as e:
-            print(f"❌ Error resuming monitoring for {transfer_id}: {e}")
+        except psutil.NoSuchProcess:
             self.transfer_model.update(transfer_id, {
-                'status': 'failed',
-                'progress': f'Monitoring failed: {e}',
+                'status': 'completed',
+                'progress': 'Transfer process ended before restart monitoring attached',
                 'end_time': datetime.now().isoformat()
             })
+        except Exception as e:
+            print(f"❌ Error resuming monitoring for {transfer_id}: {e}")
+            refreshed_transfer = self.transfer_model.get(transfer_id)
+            if refreshed_transfer and refreshed_transfer['status'] == 'running':
+                self.transfer_model.update(transfer_id, {
+                    'status': 'failed',
+                    'progress': f'Monitoring failed: {e}',
+                    'end_time': datetime.now().isoformat()
+                })

--- a/services/transfer_service.py
+++ b/services/transfer_service.py
@@ -599,9 +599,12 @@ class TransferService:
         """Resume transfers that were running when app was stopped"""
         active_transfers = self.transfer_model.get_all()
         resumed_count = 0
+        active_running_transfer_ids = []
         
         for transfer in active_transfers:
             if transfer['status'] == 'running':
+                active_running_transfer_ids.append(transfer['transfer_id'])
+
                 # Check if process is still running
                 if transfer['rsync_process_id'] and self._is_process_running(transfer['rsync_process_id']):
                     print(f"📋 Resuming monitoring for transfer {transfer['transfer_id']} (PID: {transfer['rsync_process_id']})")
@@ -623,6 +626,8 @@ class TransferService:
         
         if resumed_count > 0:
             print(f"✅ Resumed monitoring for {resumed_count} active transfers")
+
+        return active_running_transfer_ids
     
     def _is_process_running(self, pid: int) -> bool:
         """Check if a process is still running"""
@@ -671,4 +676,3 @@ class TransferService:
                 'progress': f'Monitoring failed: {e}',
                 'end_time': datetime.now().isoformat()
             })
-


### PR DESCRIPTION
## Summary
- fix same-path queued transfer promotion so promoted work re-registers in in-memory queue state before rsync starts and rebuild running reservations on restart
- persist `queue_reason` in the transfers schema/model so queue classification matches the intended slot-vs-path behavior
- refresh queue, auto-sync, schema, API, and sync analysis docs to match the current implementation and remaining gaps

## Verification
- `python3 -m py_compile services/queue_manager.py services/transfer_coordinator.py services/transfer_service.py models/database.py models/transfer.py services/auto_sync_scheduler.py services/webhook_service.py routes/webhooks.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable restart/resume: running transfers and monitors are rebuilt on startup to restore queue state.
  * Defensive start checks prevent duplicate/conflicting transfer starts and abort startups when reservations fail.
  * Improved transfer monitoring and completion handling to reduce false failures and incorrect completion propagation.

* **Documentation**
  * Major updates to queue, auto-sync, API, and database docs; clarified manual-sync representation (pending + requires_manual_sync) and queue-status visibility.
  * API reference examples and queue-capacity docs updated (max_concurrent now 3); clarified active_destinations returns transfer IDs.

* **Chores**
  * App and frontend displayed version updated to v2.1.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->