### PR TITLE
fix rename history persistence and add verify rename action

### DIFF
--- a/docs/database/v2_schema.md
+++ b/docs/database/v2_schema.md
@@ -291,7 +291,8 @@ CREATE TABLE rename_webhook (
     error_message TEXT,
     raw_webhook_data TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    processed_at DATETIME
+    completed_at DATETIME,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 )
 ```
 
@@ -310,7 +311,8 @@ CREATE TABLE rename_webhook (
 - `error_message` - Error details if failed
 - `raw_webhook_data` - Full webhook JSON payload
 - `created_at` - Record creation timestamp
-- `processed_at` - Timestamp when processing completed
+- `completed_at` - Timestamp when processing completed
+- `updated_at` - Timestamp of the last row update
 
 **Indexes:**
 - `idx_rename_webhook_notification_id` on `notification_id` - Fast lookup by notification ID

--- a/frontend/src/components/pages/webhooks.tsx
+++ b/frontend/src/components/pages/webhooks.tsx
@@ -174,6 +174,28 @@ function mapMediaType(mediaType: string) {
   return mediaType;
 }
 
+function getApiErrorMessage(error: unknown) {
+  if (typeof error !== 'object' || error === null) return undefined;
+
+  const maybeError = error as {
+    response?: {
+      data?: {
+        result?: { message?: string }
+        message?: string
+      }
+    }
+    result?: { message?: string }
+    message?: string
+  };
+
+  return (
+    maybeError.response?.data?.result?.message ??
+    maybeError.response?.data?.message ??
+    maybeError.result?.message ??
+    maybeError.message
+  );
+}
+
 export function WebhooksPage() {
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [activeTab, setActiveTab] = useState('notifications');
@@ -338,8 +360,8 @@ export function WebhooksPage() {
       } else {
         toast.error(response.result.message);
       }
-    } catch {
-      toast.error('Failed to verify rename');
+    } catch (error) {
+      toast.error(getApiErrorMessage(error) || 'Failed to verify rename');
     } finally {
       setVerifyingRenameId(null);
     }

--- a/frontend/src/components/pages/webhooks.tsx
+++ b/frontend/src/components/pages/webhooks.tsx
@@ -7,11 +7,13 @@ import {
   useRenameNotificationDetails,
   useRenameNotifications,
   useTriggerWebhookSync,
+  useVerifyRenameNotification,
   useWebhookDryRun,
   useWebhookNotificationDetails,
   useWebhookNotificationJson,
   useWebhookNotifications,
   type RenameNotification,
+  type RenameVerificationResult,
   type WebhookNotification,
 } from '@/hooks/useWebhooks';
 import { onRenameCompleted, onRenameWebhookReceived, onWebhookCaptured, onWebhookReceived } from '@/services/socket';
@@ -182,6 +184,8 @@ export function WebhooksPage() {
   const [dryRunPayload, setDryRunPayload] = useState<unknown>(null);
 
   const [renameDetailsId, setRenameDetailsId] = useState<string | null>(null);
+  const [renameVerifyPayload, setRenameVerifyPayload] = useState<RenameVerificationResult | null>(null);
+  const [verifyingRenameId, setVerifyingRenameId] = useState<string | null>(null);
 
   const notificationsQuery = useWebhookNotifications(statusFilter === 'all' ? undefined : statusFilter, 100);
   const renameQuery = useRenameNotifications(100);
@@ -195,6 +199,7 @@ export function WebhooksPage() {
   const deleteMutation = useDeleteWebhookNotification();
   const dryRunMutation = useWebhookDryRun();
   const deleteRenameMutation = useDeleteRenameNotification();
+  const verifyRenameMutation = useVerifyRenameNotification();
 
   useEffect(() => {
     const offWebhookCaptured = onWebhookCaptured(() => {
@@ -317,6 +322,26 @@ export function WebhooksPage() {
       }
     } catch {
       toast.error('Failed to delete rename notification');
+    }
+  };
+
+  const runVerifyRename = async (notification: RenameNotification) => {
+    setVerifyingRenameId(notification.notification_id);
+    try {
+      const response = await verifyRenameMutation.mutateAsync(notification.notification_id);
+      setRenameVerifyPayload(response.result);
+
+      if (response.result.status === 'verified') {
+        toast.success(response.result.message);
+      } else if (response.result.status === 'partial') {
+        toast.warning(response.result.message);
+      } else {
+        toast.error(response.result.message);
+      }
+    } catch {
+      toast.error('Failed to verify rename');
+    } finally {
+      setVerifyingRenameId(null);
     }
   };
 
@@ -515,6 +540,15 @@ export function WebhooksPage() {
                             <Button
                               size="sm"
                               variant="outline"
+                              onClick={() => runVerifyRename(notification)}
+                              disabled={verifyingRenameId === notification.notification_id}
+                            >
+                              <IconCheck className="h-4 w-4 mr-1.5" />
+                              {verifyingRenameId === notification.notification_id ? 'Verifying...' : 'Verify Rename'}
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="outline"
                               onClick={() => window.open(`/api/webhook/rename/notifications/${notification.notification_id}/json`, '_blank')}
                             >
                               <IconCode className="h-4 w-4 mr-1.5" />
@@ -700,7 +734,7 @@ export function WebhooksPage() {
           </DialogHeader>
           {renameDetailsQuery.data?.notification ? (
             <div className="space-y-4">
-              <div className="grid gap-3 md:grid-cols-3 text-sm">
+              <div className="grid gap-3 md:grid-cols-4 text-sm">
                 <div className="rounded border border-neutral-800 bg-neutral-950 p-3">
                   <div className="text-neutral-500">Series</div>
                   <div className="text-neutral-200 mt-1">{renameDetailsQuery.data.notification.series_title}</div>
@@ -715,6 +749,34 @@ export function WebhooksPage() {
                     {renameDetailsQuery.data.notification.success_count}/{renameDetailsQuery.data.notification.total_files} successful
                   </div>
                 </div>
+                <div className="rounded border border-neutral-800 bg-neutral-950 p-3">
+                  <div className="text-neutral-500">Completed</div>
+                  <div className="text-neutral-200 mt-1">
+                    {renameDetailsQuery.data.notification.completed_at
+                      ? new Date(renameDetailsQuery.data.notification.completed_at).toLocaleString()
+                      : 'Not completed'}
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => runVerifyRename(renameDetailsQuery.data.notification)}
+                  disabled={verifyingRenameId === renameDetailsQuery.data.notification.notification_id}
+                >
+                  <IconCheck className="h-4 w-4 mr-1.5" />
+                  {verifyingRenameId === renameDetailsQuery.data.notification.notification_id ? 'Verifying...' : 'Verify Rename'}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => window.open(`/api/webhook/rename/notifications/${renameDetailsQuery.data.notification.notification_id}/json`, '_blank')}
+                >
+                  <IconCode className="h-4 w-4 mr-1.5" />
+                  JSON
+                </Button>
               </div>
 
               <ScrollArea className="h-[50vh] pr-3">
@@ -733,6 +795,22 @@ export function WebhooksPage() {
           ) : (
             <div className="text-neutral-500">Loading...</div>
           )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(renameVerifyPayload)} onOpenChange={(open) => !open && setRenameVerifyPayload(null)}>
+        <DialogContent className="max-w-4xl bg-neutral-900 border-neutral-800">
+          <DialogHeader>
+            <DialogTitle className="text-white">Rename Verification</DialogTitle>
+            <DialogDescription className="text-neutral-400">
+              On-disk check against the expected TO filenames from the stored Sonarr webhook
+            </DialogDescription>
+          </DialogHeader>
+          <Textarea
+            readOnly
+            className="min-h-[60vh] bg-neutral-950 border-neutral-800 font-mono text-xs"
+            value={renameVerifyPayload ? JSON.stringify(renameVerifyPayload, null, 2) : 'No verification output'}
+          />
         </DialogContent>
       </Dialog>
     </div>

--- a/frontend/src/hooks/useWebhooks.ts
+++ b/frontend/src/hooks/useWebhooks.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '@/lib/api';
-import type { RenameNotification, WebhookNotification } from '@/lib/api-types';
-export type { RenameNotification, WebhookNotification } from '@/lib/api-types';
+import type { RenameNotification, RenameVerificationResult, WebhookNotification } from '@/lib/api-types';
+export type { RenameNotification, RenameVerificationResult, WebhookNotification } from '@/lib/api-types';
 
 export interface WebhookSettings {
   auto_sync_movies: boolean;
@@ -79,6 +79,18 @@ export function useDeleteRenameNotification() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['webhooks', 'rename'] });
+    },
+  });
+}
+
+export function useVerifyRenameNotification() {
+  return useMutation({
+    mutationFn: async (notificationId: string) => {
+      const response = await api.post<{
+        status: string;
+        result: RenameVerificationResult;
+      }>(`/webhook/rename/notifications/${notificationId}/verify`);
+      return response.data;
     },
   });
 }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -112,13 +112,39 @@ export interface RenameNotification {
   success_count: number
   failed_count: number
   created_at?: string
-  processed_at?: string
+  completed_at?: string
   renamed_files?: Array<{
     previous_name?: string
     new_name?: string
+    previous_relative_path?: string
+    new_relative_path?: string
     status?: string
     message?: string
     error?: string
+    local_previous_path?: string | null
+    local_new_path?: string | null
+  }>
+}
+
+export interface RenameVerificationResult {
+  notification_id: string
+  series_title: string
+  media_type?: string
+  status: 'verified' | 'partial' | 'failed' | 'not_found' | string
+  total_files: number
+  verified_count: number
+  failed_count: number
+  verified_at?: string
+  message: string
+  files: Array<{
+    previous_name?: string
+    expected_name?: string
+    local_previous_path?: string | null
+    local_expected_path?: string | null
+    actual_name?: string | null
+    actual_path?: string | null
+    status?: 'verified' | 'failed' | string
+    message?: string
   }>
 }
 

--- a/routes/webhooks.py
+++ b/routes/webhooks.py
@@ -1431,3 +1431,35 @@ def api_rename_notification_delete(notification_id):
             "status": "error",
             "message": f"Failed to delete rename notification: {str(e)}"
         }), 500
+
+
+@webhooks_bp.route('/webhook/rename/notifications/<notification_id>/verify', methods=['POST'])
+@require_auth
+def api_rename_notification_verify(notification_id):
+    """Verify renamed files against the expected Sonarr target filenames."""
+    try:
+        if not rename_service:
+            return jsonify({
+                "status": "error",
+                "message": "Rename service not initialized"
+            }), 500
+
+        success, result = rename_service.verify_rename_notification(notification_id)
+
+        if not success and result.get('status') == 'not_found':
+            return jsonify({
+                "status": "error",
+                "message": result.get('message', 'Rename notification not found')
+            }), 404
+
+        return jsonify({
+            "status": "success" if success else "error",
+            "result": result
+        }), 200 if success else 400
+
+    except Exception as e:
+        print(f"❌ Error verifying rename notification: {e}")
+        return jsonify({
+            "status": "error",
+            "message": f"Failed to verify rename notification: {str(e)}"
+        }), 500

--- a/services/rename_service.py
+++ b/services/rename_service.py
@@ -409,7 +409,11 @@ class RenameService:
         return local_path
 
     def _extract_verification_files(self, notification: Dict) -> List[Dict]:
-        """Prefer stored webhook JSON, then fall back to persisted rename rows."""
+        """Prefer persisted rename results, then fall back to stored webhook JSON."""
+        renamed_files = notification.get('renamed_files')
+        if isinstance(renamed_files, list) and renamed_files:
+            return renamed_files
+
         raw_webhook_data = notification.get('raw_webhook_data')
         if raw_webhook_data:
             try:
@@ -418,7 +422,6 @@ class RenameService:
             except (TypeError, ValueError, json.JSONDecodeError) as e:
                 print(f"⚠️  Failed to parse stored rename webhook JSON for verification: {e}")
 
-        renamed_files = notification.get('renamed_files') or []
         if isinstance(renamed_files, list):
             return renamed_files
         return []

--- a/services/rename_service.py
+++ b/services/rename_service.py
@@ -100,27 +100,39 @@ class RenameService:
             # This is stored in error_message field but contains all logs
             error_message = "\n".join(operation_logs) if operation_logs else None
             
+            completed_at = datetime.now().isoformat()
+
             # Update notification in database
-            self.rename_model.update(notification_id, {
+            update_succeeded = self.rename_model.update(notification_id, {
                 'renamed_files': renamed_files,
                 'success_count': success_count,
                 'failed_count': failed_count,
                 'status': status,
                 'error_message': error_message,
-                'processed_at': datetime.now().isoformat()
+                'completed_at': completed_at
             })
             
             # Build result
             result = {
                 'notification_id': notification_id,
                 'series_title': rename_data['series_title'],
+                'media_type': rename_data['media_type'],
                 'total_files': rename_data['total_files'],
                 'success_count': success_count,
                 'failed_count': failed_count,
                 'status': status,
                 'renamed_files': renamed_files,
+                'completed_at': completed_at,
                 'message': self._build_result_message(rename_data['series_title'], success_count, failed_count)
             }
+
+            if not update_succeeded:
+                result['message'] = (
+                    f"Rename completed on disk for {rename_data['series_title']}, but Rename History could not be updated"
+                )
+                result['persistence_error'] = True
+                print(f"⚠️  {result['message']}")
+                return False, result
             
             # Emit completion WebSocket event
             if self.socketio:
@@ -132,8 +144,6 @@ class RenameService:
             
             # Send Discord notification
             if self.notification_service:
-                # Add media_type to result for notification
-                result['media_type'] = rename_data['media_type']
                 self.notification_service.send_rename_discord_notification(result)
             
             return (status != 'failed', result)
@@ -147,6 +157,65 @@ class RenameService:
                 'message': f"Failed to process rename webhook: {str(e)}",
                 'error': str(e)
             })
+
+    def verify_rename_notification(self, notification_id: str) -> Tuple[bool, Dict]:
+        """Verify that renamed files exist locally at the expected target paths."""
+        notification = self.rename_model.get(notification_id)
+        if not notification:
+            return False, {
+                'status': 'not_found',
+                'message': 'Rename notification not found'
+            }
+
+        files_to_verify = self._extract_verification_files(notification)
+        if not files_to_verify:
+            return False, {
+                'notification_id': notification_id,
+                'series_title': notification.get('series_title', 'Unknown Series'),
+                'status': 'failed',
+                'message': 'No renamed files are available for verification'
+            }
+
+        verified_files = []
+        verified_count = 0
+        failed_count = 0
+
+        for file_info in files_to_verify:
+            verification = self._verify_local_rename(
+                file_info,
+                notification.get('series_path', ''),
+                notification.get('media_type', ''),
+            )
+            verified_files.append(verification)
+            if verification['status'] == 'verified':
+                verified_count += 1
+            else:
+                failed_count += 1
+
+        if failed_count == 0:
+            status = 'verified'
+        elif verified_count == 0:
+            status = 'failed'
+        else:
+            status = 'partial'
+
+        result = {
+            'notification_id': notification_id,
+            'series_title': notification.get('series_title', 'Unknown Series'),
+            'media_type': notification.get('media_type'),
+            'status': status,
+            'total_files': len(verified_files),
+            'verified_count': verified_count,
+            'failed_count': failed_count,
+            'verified_at': datetime.now().isoformat(),
+            'files': verified_files,
+            'message': self._build_verification_message(
+                notification.get('series_title', 'Unknown Series'),
+                verified_count,
+                failed_count,
+            ),
+        }
+        return True, result
     
     def _parse_rename_data(self, webhook_data: Dict, media_type: str) -> Dict:
         """
@@ -338,6 +407,68 @@ class RenameService:
         local_path = os.path.join(dest_base, series_folder_name, relative_path_normalized)
         
         return local_path
+
+    def _extract_verification_files(self, notification: Dict) -> List[Dict]:
+        """Prefer stored webhook JSON, then fall back to persisted rename rows."""
+        raw_webhook_data = notification.get('raw_webhook_data')
+        if raw_webhook_data:
+            try:
+                parsed = self._parse_rename_data(json.loads(raw_webhook_data), notification.get('media_type', ''))
+                return parsed.get('renamed_files', [])
+            except (TypeError, ValueError, json.JSONDecodeError) as e:
+                print(f"⚠️  Failed to parse stored rename webhook JSON for verification: {e}")
+
+        renamed_files = notification.get('renamed_files') or []
+        if isinstance(renamed_files, list):
+            return renamed_files
+        return []
+
+    def _verify_local_rename(self, file_info: Dict, server_series_path: str, media_type: str) -> Dict:
+        """Check whether the expected renamed file exists locally."""
+        previous_name = file_info.get('previous_name') or os.path.basename(file_info.get('previous_path', ''))
+        new_name = file_info.get('new_name') or os.path.basename(file_info.get('new_path', ''))
+
+        local_previous_path = file_info.get('local_previous_path')
+        if not local_previous_path and file_info.get('previous_relative_path'):
+            local_previous_path = self._map_to_local_path(
+                file_info['previous_relative_path'],
+                server_series_path,
+                media_type,
+            )
+
+        local_new_path = file_info.get('local_new_path')
+        if not local_new_path and file_info.get('new_relative_path'):
+            local_new_path = self._map_to_local_path(
+                file_info['new_relative_path'],
+                server_series_path,
+                media_type,
+            )
+
+        result = {
+            'previous_name': previous_name,
+            'expected_name': new_name,
+            'local_previous_path': local_previous_path,
+            'local_expected_path': local_new_path,
+            'actual_name': None,
+            'actual_path': None,
+            'status': 'failed',
+            'message': 'Expected renamed file was not found locally',
+        }
+
+        if local_new_path and os.path.exists(local_new_path):
+            result['actual_name'] = os.path.basename(local_new_path)
+            result['actual_path'] = local_new_path
+            result['status'] = 'verified'
+            result['message'] = 'Expected renamed file exists locally'
+            return result
+
+        if local_previous_path and os.path.exists(local_previous_path):
+            result['actual_name'] = os.path.basename(local_previous_path)
+            result['actual_path'] = local_previous_path
+            result['message'] = 'File still exists at the previous path'
+            return result
+
+        return result
     
     def _build_result_message(self, series_title: str, success_count: int, failed_count: int) -> str:
         """
@@ -360,3 +491,12 @@ class RenameService:
         else:
             return f"Renamed {success_count}/{total} file(s) for {series_title} ({failed_count} failed)"
 
+    def _build_verification_message(self, series_title: str, verified_count: int, failed_count: int) -> str:
+        """Build a human-readable verification summary."""
+        total = verified_count + failed_count
+
+        if failed_count == 0:
+            return f"Verified {verified_count}/{total} renamed file(s) for {series_title}"
+        if verified_count == 0:
+            return f"Could not verify any renamed files for {series_title}"
+        return f"Verified {verified_count}/{total} renamed file(s) for {series_title} ({failed_count} missing)"

--- a/static/modules/webhook-manager.js
+++ b/static/modules/webhook-manager.js
@@ -2260,6 +2260,8 @@ export class WebhookManager {
                     <div class="d-flex align-items-center gap-2">
                         ${statusBadge}
                         <button class="btn btn-outline-success btn-sm"
+                                title="Verify Rename"
+                                aria-label="Verify Rename"
                                 onclick="dragonCP.webhook.verifyRenameNotification('${notification.notification_id}', this)">
                             <i class="bi bi-patch-check"></i>
                         </button>

--- a/static/modules/webhook-manager.js
+++ b/static/modules/webhook-manager.js
@@ -2259,6 +2259,10 @@ export class WebhookManager {
                     </div>
                     <div class="d-flex align-items-center gap-2">
                         ${statusBadge}
+                        <button class="btn btn-outline-success btn-sm"
+                                onclick="dragonCP.webhook.verifyRenameNotification('${notification.notification_id}', this)">
+                            <i class="bi bi-patch-check"></i>
+                        </button>
                         <button class="btn btn-outline-secondary btn-sm" 
                                 onclick="dragonCP.webhook.showRenameDetails('${notification.notification_id}')">
                             <i class="bi bi-eye"></i>
@@ -2336,8 +2340,9 @@ export class WebhookManager {
         const statusBadge = this.getRenameStatusBadge(notification.status);
         const createdAt = notification.created_at ? 
             new Date(notification.created_at).toLocaleString() : 'Unknown';
-        const processedAt = notification.processed_at ? 
-            new Date(notification.processed_at).toLocaleString() : 'Not processed';
+        const completedAtValue = notification.completed_at || notification.processed_at;
+        const completedAt = completedAtValue ? 
+            new Date(completedAtValue).toLocaleString() : 'Not completed';
         
         // Calculate progress percentage
         const total = notification.total_files || 0;
@@ -2436,8 +2441,9 @@ export class WebhookManager {
                             ${notification.media_type === 'anime' ? 'Anime' : 'Series'}
                         </span>
                         ${statusBadge}
-                        <small class="text-muted">${processedAt}</small>
+                        <small class="text-muted">Completed: ${completedAt}</small>
                     </div>
+                    <small class="text-muted d-block mt-2">Created: ${createdAt}</small>
                 </div>
                 <div class="text-end mt-2 mt-md-0">
                     <div class="d-flex align-items-center gap-3">
@@ -2485,6 +2491,9 @@ export class WebhookManager {
         const footer = document.getElementById('renameDetailsFooter');
         if (footer) {
             footer.innerHTML = `
+                <button type="button" class="btn btn-outline-success btn-sm" onclick="dragonCP.webhook.verifyRenameNotification('${notification.notification_id}', this)">
+                    <i class="bi bi-patch-check me-1"></i> Verify Rename
+                </button>
                 <button type="button" class="btn btn-outline-info btn-sm" onclick="dragonCP.webhook.viewRenameWebhookJson('${notification.notification_id}')">
                     <i class="bi bi-code-square me-1"></i> View JSON
                 </button>
@@ -2498,6 +2507,38 @@ export class WebhookManager {
     
     viewRenameWebhookJson(notificationId) {
         this.showProtectedJson(`/api/webhook/rename/notifications/${notificationId}/json`, 'Rename Webhook JSON');
+    }
+
+    async verifyRenameNotification(notificationId, button = null) {
+        const originalHtml = button ? button.innerHTML : null;
+        if (button) {
+            button.disabled = true;
+            button.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>';
+        }
+
+        try {
+            const response = await this.app.api.fetch(`/api/webhook/rename/notifications/${notificationId}/verify`, {
+                method: 'POST'
+            });
+            const result = await response.json();
+
+            if (result.status === 'success') {
+                const alertType = result.result?.status === 'verified' ? 'success' :
+                    result.result?.status === 'partial' ? 'warning' : 'danger';
+                this.app.ui.showAlert(result.result?.message || 'Rename verification completed', alertType);
+            } else {
+                const message = result.result?.message || result.message || 'Failed to verify rename notification';
+                this.app.ui.showAlert(message, 'danger');
+            }
+        } catch (error) {
+            console.error('Failed to verify rename notification:', error);
+            this.app.ui.showAlert('Failed to verify rename notification', 'danger');
+        } finally {
+            if (button) {
+                button.disabled = false;
+                button.innerHTML = originalHtml;
+            }
+        }
     }
     
     async deleteRenameNotification(notificationId) {

--- a/tests/test_rename_service.py
+++ b/tests/test_rename_service.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -45,6 +46,7 @@ class RenameServiceTests(unittest.TestCase):
             'S01E09 - 009 - The Assassin Sees The Sights [Anime Dual-Audio WEBDL-1080p][JA+EN][VARYG-Dragon DB].mkv'
         )
         self.previous_local_path = os.path.join(self.anime_dest, self.series_folder, self.previous_relative_path)
+        self.new_local_path = os.path.join(self.anime_dest, self.series_folder, self.new_relative_path)
         os.makedirs(os.path.dirname(self.previous_local_path), exist_ok=True)
         with open(self.previous_local_path, 'w', encoding='utf-8') as handle:
             handle.write('test payload')
@@ -96,6 +98,16 @@ class RenameServiceTests(unittest.TestCase):
         self.assertEqual(verify_result['failed_count'], 0)
         self.assertEqual(verify_result['files'][0]['status'], 'verified')
         self.assertIn('Expected renamed file exists locally', verify_result['files'][0]['message'])
+
+    def test_process_rename_webhook_reports_persistence_failure_after_rename(self):
+        with patch.object(self.rename_model, 'update', return_value=False) as mocked_update:
+            success, result = self.service.process_rename_webhook(self.webhook_data, 'anime')
+
+        self.assertFalse(success)
+        self.assertTrue(result['persistence_error'])
+        self.assertTrue(mocked_update.called)
+        self.assertFalse(os.path.exists(self.previous_local_path))
+        self.assertTrue(os.path.exists(self.new_local_path))
 
 
 if __name__ == '__main__':

--- a/tests/test_rename_service.py
+++ b/tests/test_rename_service.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from models.database import DatabaseManager
+from models.webhook import RenameNotification
+from services.rename_service import RenameService
+
+
+class RenameServiceTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+
+        self.anime_dest = os.path.join(self.tempdir.name, 'anime')
+        os.makedirs(self.anime_dest, exist_ok=True)
+
+        db_path = os.path.join(self.tempdir.name, 'rename_service_test.db')
+        self.db = DatabaseManager(db_path)
+        self.rename_model = RenameNotification(self.db)
+        self.service = RenameService(
+            {
+                'ANIME_DEST_PATH': self.anime_dest,
+                'TVSHOW_DEST_PATH': os.path.join(self.tempdir.name, 'tvshows'),
+            },
+            self.rename_model,
+        )
+
+        self.series_folder = 'My Status as an Assassin Obviously Exceeds the Hero\'s (2025)'
+        self.series_path = f'/remote/anime/{self.series_folder}'
+        self.previous_relative_path = (
+            'Season 01/My Status as an Assassin Obviously Exceeds the Hero\'s (2025) - '
+            'S01E09 - 009 - The Assassin Sees The Sights [WEBDL-1080p][JA+EN][VARYG-Dragon DB].mkv'
+        )
+        self.new_relative_path = (
+            'Season 01/My Status as an Assassin Obviously Exceeds the Hero\'s (2025) - '
+            'S01E09 - 009 - The Assassin Sees The Sights [Anime Dual-Audio WEBDL-1080p][JA+EN][VARYG-Dragon DB].mkv'
+        )
+        self.previous_local_path = os.path.join(self.anime_dest, self.series_folder, self.previous_relative_path)
+        os.makedirs(os.path.dirname(self.previous_local_path), exist_ok=True)
+        with open(self.previous_local_path, 'w', encoding='utf-8') as handle:
+            handle.write('test payload')
+
+        self.webhook_data = {
+            'eventType': 'Rename',
+            'series': {
+                'id': 277,
+                'title': self.series_folder,
+                'path': self.series_path,
+            },
+            'renamedEpisodeFiles': [
+                {
+                    'id': 9,
+                    'previousPath': f'{self.series_path}/{self.previous_relative_path}',
+                    'previousRelativePath': self.previous_relative_path,
+                    'path': f'{self.series_path}/{self.new_relative_path}',
+                    'relativePath': self.new_relative_path,
+                }
+            ],
+        }
+
+    def test_process_rename_webhook_persists_completed_at(self):
+        success, result = self.service.process_rename_webhook(self.webhook_data, 'anime')
+
+        self.assertTrue(success)
+        self.assertEqual(result['status'], 'completed')
+        self.assertIsNotNone(result.get('completed_at'))
+
+        saved_notification = self.rename_model.get(result['notification_id'])
+        self.assertIsNotNone(saved_notification)
+        self.assertEqual(saved_notification['status'], 'completed')
+        self.assertEqual(saved_notification['success_count'], 1)
+        self.assertEqual(saved_notification['failed_count'], 0)
+        self.assertIsNotNone(saved_notification.get('completed_at'))
+        self.assertEqual(saved_notification['renamed_files'][0]['status'], 'success')
+        self.assertFalse(os.path.exists(self.previous_local_path))
+        self.assertTrue(os.path.exists(saved_notification['renamed_files'][0]['local_new_path']))
+
+    def test_verify_rename_notification_checks_expected_target_path(self):
+        success, result = self.service.process_rename_webhook(self.webhook_data, 'anime')
+        self.assertTrue(success)
+
+        verified, verify_result = self.service.verify_rename_notification(result['notification_id'])
+
+        self.assertTrue(verified)
+        self.assertEqual(verify_result['status'], 'verified')
+        self.assertEqual(verify_result['verified_count'], 1)
+        self.assertEqual(verify_result['failed_count'], 0)
+        self.assertEqual(verify_result['files'][0]['status'], 'verified')
+        self.assertIn('Expected renamed file exists locally', verify_result['files'][0]['message'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix issue #48 by persisting rename completion to `completed_at`, surfacing persistence failures, and aligning the legacy/React rename history views with the v2 schema
- add a manual `Verify Rename` action for rename history in both the legacy UI and React UI that checks local files against the expected `TO` filenames from the stored Sonarr webhook payload
- add backend regression coverage for rename completion persistence and rename verification, and update the schema docs for `rename_webhook`

## Testing
- `venv/bin/python -m unittest discover -s tests -p "test_rename_service.py"`
- `venv/bin/python -m py_compile services/rename_service.py routes/webhooks.py`
- React build not run in this environment because `npm` is unavailable

Closes #48.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add rename verification flow with per-notification "Verify Rename" actions, a verification modal showing detailed per-file results, and status-toasts during verification.

* **Documentation**
  * Update database schema docs to replace a processed timestamp with a completed timestamp and add an updated-at column for row update tracking.

* **Tests**
  * Add integration tests covering rename processing, persistence behavior, and the verification workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->