### PR TITLE
Fix Browse Media hidden on mobile/Tailscale (issue #50) [v2.1.4]

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,7 +11,7 @@ from flask import session, has_request_context
 
 
 # Application version for cache busting
-APP_VERSION = "2.1.3"
+APP_VERSION = "2.1.4"
 
 
 class DragonCPConfig:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "dependencies": {
         "@base-ui/react": "^1.0.0",
         "@fontsource-variable/nunito-sans": "^5.2.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/layout/app-layout.tsx
+++ b/frontend/src/components/layout/app-layout.tsx
@@ -32,7 +32,7 @@ interface AppLayoutProps {
 }
 
 // App version - can be made configurable from env or API later
-const APP_VERSION = 'v2.1.3';
+const APP_VERSION = 'v2.1.4';
 
 // Dragon-CP Logo URL
 const LOGO_URL = 'https://blog.infinitysystems.in/dragondbserver/DragonDB_Trans.png';

--- a/static/app.js
+++ b/static/app.js
@@ -318,14 +318,25 @@ class DragonCPUI {
             // hasEverConnected was already true, so auto-connect was skipped entirely
             // and Browse Media would stay hidden (issue #50).
             if (!this.hasAttemptedAutoConnect) {
-                this.hasAttemptedAutoConnect = true;
                 if (!this.websocket.isWebSocketConnected) {
                     this.websocket.connect();
                 }
-                const autoConnectResponse = await this.api.fetch('/api/auto-connect');
-                const autoConnectResult = await autoConnectResponse.json();
+                let autoConnectResult = null;
+                try {
+                    const autoConnectResponse = await this.api.fetch('/api/auto-connect');
+                    autoConnectResult = await autoConnectResponse.json();
+                } catch (fetchError) {
+                    console.error('Auto-connect fetch failed:', fetchError);
+                }
 
-                if (autoConnectResult.status === 'success') {
+                console.log('autoConnect:', {
+                    state: { hasAttemptedAutoConnect: this.hasAttemptedAutoConnect, connected: this.currentState.connected },
+                    websocket: { isConnected: this.websocket.isWebSocketConnected, hasEverConnected: this.websocket.hasEverConnected, transport: this.websocket.lastTransport },
+                    result: autoConnectResult
+                });
+
+                if (autoConnectResult?.status === 'success') {
+                    this.hasAttemptedAutoConnect = true;
                     this.currentState.connected = true;
                     this.ui.updateStatus('Connected to server', 'connected');
                     this.ui.showAlert('Auto-connected successfully!', 'success');
@@ -333,6 +344,8 @@ class DragonCPUI {
                     this.media.loadMediaTypes();
                     return;
                 }
+                // Auto-connect failed or fetch errored — don't set hasAttemptedAutoConnect
+                // so subsequent sessions (e.g. re-login) can retry automatically.
             }
             // If auto-connect fails, check if we have credentials
             if (this.config.hasConnectionCredentials()) {

--- a/static/app.js
+++ b/static/app.js
@@ -32,6 +32,7 @@ class DragonCPUI {
         this.modulesInitialized = false;
         this.isBootstrapping = false;
         this.handlingSessionExpiry = false;
+        this.hasAttemptedAutoConnect = false;
 
         // Core modules
         this.ui = new UIComponents(this);
@@ -275,6 +276,7 @@ class DragonCPUI {
 
     handleAuthLogout(reason) {
         this.currentState.connected = false;
+        this.hasAttemptedAutoConnect = false;
         this.updateAuthUI(false);
 
         if (this.websocket) {
@@ -306,18 +308,23 @@ class DragonCPUI {
     async initializeConnection() {
         try {
             this.ui.updateStatus('Initializing application...', 'connecting');
-            
+
             // Load configuration first
             await this.config.loadConfiguration();
-            
-            // Only auto-connect on first load
-            if (!this.websocket.hasEverConnected) {
+
+            // Attempt SSH auto-connect on first load, independent of WebSocket state.
+            // Previously this was gated on !this.websocket.hasEverConnected, which
+            // caused a race condition: if Socket.IO connected before this point,
+            // hasEverConnected was already true, so auto-connect was skipped entirely
+            // and Browse Media would stay hidden (issue #50).
+            if (!this.hasAttemptedAutoConnect) {
+                this.hasAttemptedAutoConnect = true;
                 if (!this.websocket.isWebSocketConnected) {
                     this.websocket.connect();
                 }
                 const autoConnectResponse = await this.api.fetch('/api/auto-connect');
                 const autoConnectResult = await autoConnectResponse.json();
-                
+
                 if (autoConnectResult.status === 'success') {
                     this.currentState.connected = true;
                     this.ui.updateStatus('Connected to server', 'connected');


### PR DESCRIPTION
## Summary
- **Fix race condition** in legacy UI where `Browse Media` intermittently stayed hidden on mobile browsers over Tailscale. The SSH auto-connect in `initializeConnection()` was gated on `!this.websocket.hasEverConnected`, which became `true` as soon as Socket.IO connected — often before the auto-connect check ran — causing `/api/auto-connect` to be skipped entirely.
- **Introduced `hasAttemptedAutoConnect` flag** on the app instance to track SSH auto-connect attempts independently of WebSocket state. The flag is reset on logout so re-login works correctly.
- **Bumped version** from v2.1.3 → v2.1.4 across `config.py`, `package.json`, `package-lock.json`, and `app-layout.tsx`.

Closes #50

## Files changed
| File | Change |
|---|---|
| `static/app.js` | New `hasAttemptedAutoConnect` flag; replaced `hasEverConnected` gate; reset flag on logout |
| `config.py` | Version bump to 2.1.4 |
| `frontend/package.json` | Version bump to 2.1.4 |
| `frontend/package-lock.json` | Version bump to 2.1.4 |
| `frontend/src/components/layout/app-layout.tsx` | Version bump to v2.1.4 |

## Test plan
- [x] Load legacy UI on mobile Firefox over Tailscale IP:port — Browse Media should appear on first load
- [x] Load legacy UI on mobile Chrome over Tailscale — same behavior, no reloads needed
- [x] Verify server logs show `/api/auto-connect` being called on every fresh page load
- [x] Verify logout → re-login correctly re-triggers auto-connect
- [x] Verify manual "Auto Connect" button still works after auto-connect failure