### PR TITLE
Webhook authentication and path traversal protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.env
 !dragoncp_env_sample.env
 
+# SSH managed known_hosts file (SEC-07, generated at runtime)
+dragoncp_known_hosts
+
 # ===================
 # Python
 # ===================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,9 @@
   - queue behavior: `docs/queue-management/QUEUE_MANAGEMENT_IMPLEMENTATION.md`
   - frontend React details: `docs/frontend/FRONTEND_REFERENCE.md`
   - API endpoints: `docs/api/API_REFERENCE.md`
+
+## Attribution Policy
+
+- Do not add any AI/Claude attribution to commit messages, PR descriptions, or code comments.
+- No `Co-Authored-By`, no "Generated with Claude Code", no similar attribution lines.
+- This applies across all projects.

--- a/app.py
+++ b/app.py
@@ -365,7 +365,11 @@ def api_connect():
         print("❌ Missing host or username")
         return jsonify({"status": "error", "message": "Host and username are required"})
     
-    ssh_manager = SSHManager(host, username, password, key_path)
+    ssh_manager = SSHManager(
+        host, username, password, key_path,
+        host_key_policy=config.get("SSH_HOST_KEY_CHECKING", "accept-new"),
+        known_hosts_file=config.get("SSH_KNOWN_HOSTS_FILE", ""),
+    )
     if ssh_manager.connect():
         print("✅ SSH connection successful")
         session['ssh_connected'] = True
@@ -419,7 +423,11 @@ def api_auto_connect():
         print("❌ Missing REMOTE_IP or REMOTE_USER in config")
         return jsonify({"status": "error", "message": "SSH credentials not configured"})
     
-    ssh_manager = SSHManager(host, username, password or '', key_path or '')
+    ssh_manager = SSHManager(
+        host, username, password or '', key_path or '',
+        host_key_policy=config.get("SSH_HOST_KEY_CHECKING", "accept-new"),
+        known_hosts_file=config.get("SSH_KNOWN_HOSTS_FILE", ""),
+    )
     if ssh_manager.connect():
         print("✅ Auto-connection successful")
         session['ssh_connected'] = True

--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ Manages environment configuration and session overrides
 
 import os
 from datetime import datetime
-from typing import Dict
+from typing import Dict, List
 from flask import session, has_request_context
 
 
@@ -81,6 +81,41 @@ class DragonCPConfig:
         session['ui_config'] = current_session_config
         print(f"✅ Session configuration updated: {list(config_data.keys())}")
     
+    def get_all_allowed_paths(self) -> List[str]:
+        """
+        Get all configured directory paths that define filesystem security boundaries.
+
+        SECURITY: These paths are the ONLY directories DragonCP is allowed to
+        operate in. All file operations (read, write, rename, delete, rsync,
+        backup/restore) MUST validate that constructed paths resolve within
+        one of these directories. See security.py for enforcement functions.
+
+        Returns:
+            List of configured directory paths (empty strings filtered out)
+        """
+        path_keys = [
+            'MOVIE_PATH', 'TVSHOW_PATH', 'ANIME_PATH',
+            'MOVIE_DEST_PATH', 'TVSHOW_DEST_PATH', 'ANIME_DEST_PATH',
+            'BACKUP_PATH'
+        ]
+        return [self.get(k) for k in path_keys if self.get(k)]
+
+    def get_destination_paths(self) -> List[str]:
+        """
+        Get all configured LOCAL destination paths.
+
+        SECURITY: These are the local filesystem directories where DragonCP
+        writes data. Path traversal protection is most critical for these
+        paths since the Flask process has direct filesystem access.
+
+        Returns:
+            List of configured destination directory paths (empty strings filtered out)
+        """
+        dest_keys = [
+            'MOVIE_DEST_PATH', 'TVSHOW_DEST_PATH', 'ANIME_DEST_PATH'
+        ]
+        return [self.get(k) for k in dest_keys if self.get(k)]
+
     def save_config(self, config_data: Dict[str, str]):
         """Save configuration to .env file (legacy method - use update_session_config instead)"""
         try:

--- a/dragoncp_env_sample.env
+++ b/dragoncp_env_sample.env
@@ -42,6 +42,19 @@ ANIME_DEST_PATH="/local/path/to/anime"
 # ===== BACKUP CONFIGURATION =====
 BACKUP_PATH="/path/to/backup"
 
+# ===== WEBHOOK SECURITY =====
+# HMAC secret for verifying webhook signatures via X-DragonCP-Signature header.
+# When configured, webhook requests must include a valid signature or come from
+# a whitelisted IP (if WEBHOOK_ALLOWED_IPS is also set).
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"
+# WEBHOOK_SECRET=""
+
+# Comma-separated list of allowed webhook source IPs or CIDR ranges.
+# Requests from these IPs are allowed through without signature verification.
+# Supports individual IPs and CIDR notation (e.g., "192.168.1.0/24").
+# Example: "192.168.1.100,10.0.0.0/24,100.64.0.0/10"
+# WEBHOOK_ALLOWED_IPS=""
+
 # ===== DISK USAGE MONITORING =====
 # Local disk paths to monitor (uses df -h <path>)
 DISK_PATH_1="<path>"

--- a/dragoncp_env_sample.env
+++ b/dragoncp_env_sample.env
@@ -29,6 +29,20 @@ REMOTE_USER="username"
 REMOTE_PASSWORD="your-password-here"
 SSH_KEY_PATH="/path/to/your/private/key"
 
+# ===== SSH HOST-KEY VERIFICATION (SEC-07) =====
+# Controls how the remote server's SSH host key is verified (protects against
+# man-in-the-middle attacks). Applies to both browsing (paramiko) and rsync.
+#   strict      = only connect to hosts already in the known_hosts file (most secure;
+#                 provision the key first, e.g. `ssh-keyscan <host> >> <known_hosts>`)
+#   accept-new  = trust-on-first-use: record the key on first connect, reject it if
+#                 it later CHANGES (DEFAULT — secure yet usable)
+#   no          = INSECURE legacy behaviour: accept any key (vulnerable to MITM)
+# SSH_HOST_KEY_CHECKING="accept-new"
+#
+# Path to the managed known_hosts file (must not contain spaces).
+# Defaults to <app_dir>/dragoncp_known_hosts when unset.
+# SSH_KNOWN_HOSTS_FILE=""
+
 # ===== MEDIA SOURCE PATHS (Remote Server) =====
 MOVIE_PATH="/path/to/movies"
 TVSHOW_PATH="/path/to/tvshows"

--- a/routes/backups.py
+++ b/routes/backups.py
@@ -2,10 +2,16 @@
 """
 DragonCP Backup Routes
 Handles backup operations: list, get, restore, delete, plan, reindex
+
+SECURITY: File paths from restore requests are validated through
+security.validate_relative_path() to prevent directory traversal.
+Service-level validation in backup_service.py provides additional
+bounds checking. See security.py for details.
 """
 
 from flask import Blueprint, jsonify, request
 from auth import require_auth
+from security import validate_relative_path
 
 backups_bp = Blueprint('backups', __name__)
 
@@ -73,6 +79,18 @@ def api_restore_backup(backup_id):
         files = payload.get('files')
         if files and not isinstance(files, list):
             return jsonify({"status": "error", "message": "'files' must be a list of relative paths"}), 400
+
+        # SECURITY: Validate each file path in the restore list to prevent
+        # directory traversal. Reject paths containing "..", absolute paths,
+        # or null bytes. See security.py for details.
+        if files:
+            for file_path in files:
+                if not isinstance(file_path, str) or not validate_relative_path(file_path):
+                    return jsonify({
+                        "status": "error",
+                        "message": f"Invalid file path rejected: {file_path}"
+                    }), 400
+
         ok, msg = transfer_coordinator.restore_backup(backup_id, files)
         if ok:
             return jsonify({"status": "success", "message": msg})

--- a/routes/backups.py
+++ b/routes/backups.py
@@ -77,13 +77,18 @@ def api_restore_backup(backup_id):
     try:
         payload = request.json or {}
         files = payload.get('files')
-        if files and not isinstance(files, list):
-            return jsonify({"status": "error", "message": "'files' must be a list of relative paths"}), 400
 
-        # SECURITY: Validate each file path in the restore list to prevent
-        # directory traversal. Reject paths containing "..", absolute paths,
-        # or null bytes. See security.py for details.
-        if files:
+        # If 'files' key was explicitly provided, enforce it must be a non-empty list.
+        # None means "restore all"; [] means "user selected nothing" -> reject.
+        if files is not None:
+            if not isinstance(files, list):
+                return jsonify({"status": "error", "message": "'files' must be a list of relative paths"}), 400
+            if len(files) == 0:
+                return jsonify({"status": "error", "message": "Empty file selection not allowed"}), 400
+
+            # SECURITY: Validate each file path in the restore list to prevent
+            # directory traversal. Reject paths containing "..", absolute paths,
+            # or null bytes. See security.py for details.
             for file_path in files:
                 if not isinstance(file_path, str) or not validate_relative_path(file_path):
                     return jsonify({

--- a/routes/media.py
+++ b/routes/media.py
@@ -12,7 +12,7 @@ See security.py for the validation implementation.
 
 from flask import Blueprint, jsonify, request
 from auth import require_auth
-from security import validate_path_component
+from security import validate_path_component, assert_path_within_bounds, PathTraversalError
 
 media_bp = Blueprint('media', __name__)
 
@@ -497,10 +497,18 @@ def api_media_dry_run():
         else:
             # For movies or entire series folder
             dest_path = f"{dest_base}/{folder_name}"
-        
+
+        # SECURITY: Resolve dest_path to its real absolute path and verify it
+        # stays within dest_base. Component validation above prevents literal
+        # traversal, but this catches symlink-based escapes.
+        try:
+            assert_path_within_bounds(dest_path, [dest_base])
+        except PathTraversalError:
+            return jsonify({"status": "error", "message": "Destination path escapes configured boundary"}), 400
+
         print(f"📁 Source: {source_path}")
         print(f"📁 Dest: {dest_path}")
-        
+
         # Perform dry-run using transfer service
         dry_run_result = transfer_coordinator.transfer_service.perform_dry_run_rsync(
             source_path=source_path,

--- a/routes/media.py
+++ b/routes/media.py
@@ -2,10 +2,17 @@
 """
 DragonCP Media Routes
 Handles media browsing and sync status endpoints
+
+SECURITY: All path components from URL parameters and POST body data
+are validated through security.validate_path_component() before being
+used to construct filesystem paths. This prevents path traversal attacks
+via crafted folder_name, season_name, or episode_name values.
+See security.py for the validation implementation.
 """
 
 from flask import Blueprint, jsonify, request
 from auth import require_auth
+from security import validate_path_component
 
 media_bp = Blueprint('media', __name__)
 
@@ -89,19 +96,23 @@ def api_folders(media_type):
 @require_auth
 def api_seasons(media_type, folder_name):
     """Get seasons for TV show or anime"""
+    # SECURITY: Validate path component to prevent directory traversal
+    if not validate_path_component(folder_name):
+        return jsonify({"status": "error", "message": "Invalid folder name"}), 400
+
     if not ssh_manager or not ssh_manager.connected:
         return jsonify({"status": "error", "message": "Not connected to server"})
-    
+
     path_map = {
         "movies": config.get("MOVIE_PATH"),
         "tvshows": config.get("TVSHOW_PATH"),
         "anime": config.get("ANIME_PATH")
     }
-    
+
     base_path = path_map.get(media_type)
     if not base_path:
         return jsonify({"status": "error", "message": "Invalid media type"})
-    
+
     full_path = f"{base_path}/{folder_name}"
     try:
         seasons_metadata = ssh_manager.list_folders_with_metadata(full_path)
@@ -119,19 +130,25 @@ def api_seasons(media_type, folder_name):
 @require_auth
 def api_episodes(media_type, folder_name, season_name):
     """Get episodes for a season"""
+    # SECURITY: Validate path components to prevent directory traversal
+    if not validate_path_component(folder_name):
+        return jsonify({"status": "error", "message": "Invalid folder name"}), 400
+    if not validate_path_component(season_name):
+        return jsonify({"status": "error", "message": "Invalid season name"}), 400
+
     if not ssh_manager or not ssh_manager.connected:
         return jsonify({"status": "error", "message": "Not connected to server"})
-    
+
     path_map = {
         "movies": config.get("MOVIE_PATH"),
         "tvshows": config.get("TVSHOW_PATH"),
         "anime": config.get("ANIME_PATH")
     }
-    
+
     base_path = path_map.get(media_type)
     if not base_path:
         return jsonify({"status": "error", "message": "Invalid media type"})
-    
+
     full_path = f"{base_path}/{folder_name}/{season_name}"
     episodes = ssh_manager.list_files(full_path)
     return jsonify({"status": "success", "episodes": episodes})
@@ -222,20 +239,24 @@ def api_sync_status(media_type):
 @require_auth
 def api_folder_sync_status(media_type, folder_name):
     """Get detailed sync status for a specific folder (useful for series/anime seasons)"""
+    # SECURITY: Validate path component to prevent directory traversal
+    if not validate_path_component(folder_name):
+        return jsonify({"status": "error", "message": "Invalid folder name"}), 400
+
     print(f"🔍 API: /api/sync-status/{media_type}/{folder_name} called")
-    
+
     if not ssh_manager or not ssh_manager.connected:
         return jsonify({"status": "error", "message": "Not connected to server"})
-    
+
     if not transfer_coordinator:
         return jsonify({"status": "error", "message": "Transfer coordinator not available"})
-    
+
     path_map = {
         "movies": config.get("MOVIE_PATH"),
         "tvshows": config.get("TVSHOW_PATH"),
         "anime": config.get("ANIME_PATH")
     }
-    
+
     path = path_map.get(media_type)
     if not path:
         return jsonify({"status": "error", "message": "Invalid media type"})
@@ -298,24 +319,28 @@ def api_folder_sync_status(media_type, folder_name):
 @require_auth
 def api_enhanced_folder_sync_status(media_type, folder_name):
     """Get enhanced sync status with detailed file information"""
+    # SECURITY: Validate path component to prevent directory traversal
+    if not validate_path_component(folder_name):
+        return jsonify({"status": "error", "message": "Invalid folder name"}), 400
+
     print(f"🔍 API: /api/sync-status/{media_type}/{folder_name}/enhanced called")
-    
+
     if not ssh_manager or not ssh_manager.connected:
         return jsonify({"status": "error", "message": "Not connected to server"})
-    
+
     if not transfer_coordinator:
         return jsonify({"status": "error", "message": "Transfer coordinator not available"})
-    
+
     path_map = {
         "movies": config.get("MOVIE_PATH"),
         "tvshows": config.get("TVSHOW_PATH"),
         "anime": config.get("ANIME_PATH")
     }
-    
+
     path = path_map.get(media_type)
     if not path:
         return jsonify({"status": "error", "message": "Invalid media type"})
-    
+
     try:
         full_path = f"{path}/{folder_name}"
         
@@ -414,7 +439,13 @@ def api_media_dry_run():
                 "status": "error",
                 "message": "media_type and folder_name are required"
             }), 400
-        
+
+        # SECURITY: Validate path components from POST body to prevent traversal
+        if not validate_path_component(folder_name):
+            return jsonify({"status": "error", "message": "Invalid folder name"}), 400
+        if season_name and not validate_path_component(season_name):
+            return jsonify({"status": "error", "message": "Invalid season name"}), 400
+
         print(f"🔍 Manual dry-run requested from media browser")
         print(f"   Media type: {media_type}")
         print(f"   Folder: {folder_name}")

--- a/routes/transfers.py
+++ b/routes/transfers.py
@@ -2,11 +2,17 @@
 """
 DragonCP Transfer Routes
 Handles transfer operations: start, status, cancel, restart, delete, cleanup
+
+SECURITY: All path components from POST body data (folder_name, season_name,
+episode_name) are validated through security.validate_path_component() before
+being used to construct filesystem paths. This prevents path traversal attacks.
+See security.py for the validation implementation.
 """
 
 import time
 from flask import Blueprint, jsonify, request
 from auth import require_auth
+from security import validate_path_component
 
 transfers_bp = Blueprint('transfers', __name__)
 
@@ -39,7 +45,17 @@ def api_transfer():
         if not media_type or not folder_name:
             print("❌ Missing media_type or folder_name")
             return jsonify({"status": "error", "message": "Media type and folder name are required"})
-        
+
+        # SECURITY: Validate all path components from POST body to prevent
+        # directory traversal. Each component must be a single path segment
+        # without "..", "/", "\", or null bytes. See security.py.
+        if not validate_path_component(folder_name):
+            return jsonify({"status": "error", "message": "Invalid folder name"}), 400
+        if season_name and not validate_path_component(season_name):
+            return jsonify({"status": "error", "message": "Invalid season name"}), 400
+        if episode_name and not validate_path_component(episode_name):
+            return jsonify({"status": "error", "message": "Invalid episode name"}), 400
+
         # Get source path from config
         source_path_map = {
             "movies": config.get("MOVIE_PATH"),

--- a/routes/transfers.py
+++ b/routes/transfers.py
@@ -12,7 +12,7 @@ See security.py for the validation implementation.
 import time
 from flask import Blueprint, jsonify, request
 from auth import require_auth
-from security import validate_path_component
+from security import validate_path_component, assert_path_within_bounds, PathTraversalError
 
 transfers_bp = Blueprint('transfers', __name__)
 
@@ -104,9 +104,17 @@ def api_transfer():
             source_path = f"{source_path}/{episode_name}"
             dest_path = f"{dest_path}/{episode_name}"
         
+        # SECURITY: Resolve dest_path to its real absolute path and verify it
+        # stays within base_dest. Component validation above prevents literal
+        # traversal, but this catches symlink-based escapes.
+        try:
+            assert_path_within_bounds(dest_path, [base_dest])
+        except PathTraversalError:
+            return jsonify({"status": "error", "message": "Destination path escapes configured boundary"}), 400
+
         print(f"📁 Final source path: {source_path}")
         print(f"📁 Final destination path: {dest_path}")
-        
+
         # Generate transfer ID
         transfer_id = f"transfer_{int(time.time())}"
         

--- a/routes/webhooks.py
+++ b/routes/webhooks.py
@@ -11,6 +11,7 @@ from flask import Blueprint, jsonify, request, Response
 import requests
 import json
 from auth import require_auth
+from webhook_auth import require_webhook_auth
 
 webhooks_bp = Blueprint('webhooks', __name__)
 
@@ -52,6 +53,7 @@ def init_webhook_routes(app_config, app_transfer_coordinator, app_rename_service
 # ===== WEBHOOK RECEIVER ENDPOINTS =====
 
 @webhooks_bp.route('/webhook/movies', methods=['POST'])
+@require_webhook_auth
 def api_webhook_movies_receiver():
     """Webhook receiver endpoint for movie notifications from Radarr"""
     try:
@@ -166,6 +168,7 @@ def api_webhook_movies_receiver():
 
 
 @webhooks_bp.route('/webhook/series', methods=['POST'])
+@require_webhook_auth
 def api_webhook_series_receiver():
     """Webhook receiver endpoint for series notifications from Sonarr"""
     try:
@@ -290,6 +293,7 @@ def api_webhook_series_receiver():
 
 
 @webhooks_bp.route('/webhook/anime', methods=['POST'])
+@require_webhook_auth
 def api_webhook_anime_receiver():
     """Webhook receiver endpoint for anime notifications from Sonarr"""
     try:

--- a/security.py
+++ b/security.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+DragonCP Security Utilities
+
+=== SECURITY BOUNDARY - READ THIS IF MODIFYING FILE OPERATIONS ===
+
+All file operations in DragonCP MUST validate paths through these functions
+before accessing the filesystem. This ensures that no webhook payload, API
+request, or any external input can escape the configured media and backup
+directories (MOVIE_PATH, TVSHOW_PATH, ANIME_PATH, *_DEST_PATH, BACKUP_PATH).
+
+If you are adding NEW file operations to DragonCP, you MUST:
+1. Validate individual path components with validate_path_component()
+2. Validate fully-constructed paths with assert_path_within_bounds()
+3. NEVER construct file paths from user/external input without validation
+4. This applies to ALL operations: read, write, rename, delete, rsync, backup
+
+The configured directory paths are the ONLY allowed filesystem scope.
+Any path that resolves outside these directories MUST be rejected.
+
+See also: webhook_auth.py for webhook endpoint authentication.
+"""
+
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class PathTraversalError(ValueError):
+    """
+    Raised when a path traversal attempt is detected.
+
+    SECURITY: This exception indicates that a user-supplied or webhook-supplied
+    path component attempted to escape the configured directory boundaries.
+    All callers should treat this as a security event and log it accordingly.
+
+    Inherits from ValueError so that existing except-ValueError blocks in
+    path_service.py catch it naturally, but callers can also catch it
+    specifically for security logging.
+    """
+    pass
+
+
+def validate_path_component(component: str) -> bool:
+    """
+    Validate a single path component (folder name, season name, episode filename).
+
+    SECURITY: This function ensures individual path segments do not contain
+    directory traversal sequences or path separators that could be used to
+    escape the configured media/backup directory boundaries.
+
+    A path component is a single segment of a path (e.g., a folder name or
+    filename). It should NOT contain directory separators or parent-directory
+    references.
+
+    Allowed: "Season 01", "Movie Title (2024)", "Show - S01E01 - Title.mkv",
+             names with unicode, colons, brackets, parens, etc.
+    Rejected: "..", "../etc", "foo/bar", "foo\\bar", "", null bytes
+
+    Args:
+        component: A single path segment to validate
+
+    Returns:
+        True if the component is safe, False if it contains traversal patterns
+    """
+    if not component or not component.strip():
+        return False
+
+    # Reject null bytes (filesystem injection)
+    if '\0' in component:
+        logger.warning("SECURITY: Null byte detected in path component: %r", component)
+        return False
+
+    # Reject parent-directory references
+    # Check for exact ".." or ".." embedded in segments like "..hidden"
+    if component == '.' or component == '..':
+        logger.warning("SECURITY: Dot/dot-dot path component rejected: %r", component)
+        return False
+
+    # Reject any component containing ".." as a directory traversal sequence
+    # This catches "../../etc", "foo..bar/../baz" etc.
+    if '..' in component:
+        logger.warning("SECURITY: Path traversal sequence '..' detected in component: %r", component)
+        return False
+
+    # Reject path separators (both Unix and Windows)
+    # A valid component should be a single directory/file name, never a sub-path
+    if '/' in component or '\\' in component:
+        logger.warning("SECURITY: Path separator detected in component: %r", component)
+        return False
+
+    return True
+
+
+def validate_resolved_path(resolved_path: str, allowed_base_paths: list) -> bool:
+    """
+    Validate that a fully-constructed path resolves within one of the allowed
+    base directories.
+
+    SECURITY: This is the core path boundary check. It resolves symlinks and
+    normalizes the path to ensure no traversal can escape the configured
+    directory scope. This function MUST be called before any filesystem
+    operation (read, write, rename, delete, rsync) on a path constructed
+    from external input.
+
+    The check uses os.path.realpath() which:
+    - Resolves all symbolic links
+    - Eliminates all ".." and "." references
+    - Returns an absolute, canonical path
+
+    Args:
+        resolved_path: The fully-constructed path to validate
+        allowed_base_paths: List of allowed base directory paths
+
+    Returns:
+        True if the path is within one of the allowed base directories,
+        False otherwise
+    """
+    if not resolved_path or not allowed_base_paths:
+        return False
+
+    # Resolve to canonical absolute path (resolves symlinks, eliminates ..)
+    real_path = os.path.realpath(resolved_path)
+
+    for base in allowed_base_paths:
+        if not base:
+            continue
+        # Resolve the base path too (in case it contains symlinks)
+        real_base = os.path.realpath(base)
+
+        # Check if the resolved path is the base itself or a child of it
+        # SECURITY: We append os.sep to prevent "/home/user" matching "/home/username"
+        if real_path == real_base or real_path.startswith(real_base + os.sep):
+            return True
+
+    return False
+
+
+def assert_path_within_bounds(path: str, allowed_base_paths: list) -> str:
+    """
+    Assert that a path resolves within one of the allowed base directories.
+    Raises PathTraversalError if the path escapes the configured boundaries.
+
+    SECURITY: This is the preferred API for service-layer code. Use this
+    instead of validate_resolved_path() when you want automatic error
+    handling. All filesystem operations on paths derived from external input
+    (webhooks, API requests, user input) MUST pass through this function.
+
+    Args:
+        path: The fully-constructed path to validate
+        allowed_base_paths: List of allowed base directory paths
+
+    Returns:
+        The resolved (canonical) path for the caller to use
+
+    Raises:
+        PathTraversalError: If the path escapes the allowed boundaries
+    """
+    if not path:
+        raise PathTraversalError("Empty path is not allowed")
+
+    # Filter out empty/None base paths
+    valid_bases = [b for b in allowed_base_paths if b]
+    if not valid_bases:
+        raise PathTraversalError(
+            "No allowed base paths configured. Cannot validate path security boundary."
+        )
+
+    real_path = os.path.realpath(path)
+
+    if not validate_resolved_path(real_path, valid_bases):
+        logger.warning(
+            "SECURITY: Path traversal blocked - path '%s' (resolved: '%s') "
+            "escapes allowed boundaries: %s",
+            path, real_path, valid_bases
+        )
+        raise PathTraversalError(
+            f"Path '{path}' resolves outside allowed directories. "
+            f"This may indicate a path traversal attempt."
+        )
+
+    return real_path
+
+
+def validate_relative_path(relative_path: str) -> bool:
+    """
+    Validate a relative path (e.g., from a webhook rename event or backup file list).
+
+    SECURITY: Relative paths from external sources (webhook payloads, API requests)
+    can contain traversal sequences. This function validates that a relative path
+    does not attempt to escape upward using ".." or start with an absolute path.
+
+    Unlike validate_path_component(), this function DOES allow forward slashes
+    (since relative paths like "Season 01/filename.mkv" are legitimate).
+    It rejects: absolute paths, ".." sequences, null bytes.
+
+    Args:
+        relative_path: A relative file path to validate
+
+    Returns:
+        True if the relative path is safe, False otherwise
+    """
+    if not relative_path or not relative_path.strip():
+        return False
+
+    # Reject null bytes
+    if '\0' in relative_path:
+        logger.warning("SECURITY: Null byte detected in relative path: %r", relative_path)
+        return False
+
+    # Reject absolute paths
+    if relative_path.startswith('/') or relative_path.startswith('\\'):
+        logger.warning("SECURITY: Absolute path rejected as relative path: %r", relative_path)
+        return False
+
+    # On Windows, also reject drive letter paths like "C:\..."
+    if len(relative_path) >= 2 and relative_path[1] == ':':
+        logger.warning("SECURITY: Windows absolute path rejected: %r", relative_path)
+        return False
+
+    # Reject ".." traversal in any segment
+    # Split on both Unix and Windows separators
+    segments = relative_path.replace('\\', '/').split('/')
+    for segment in segments:
+        if segment == '..':
+            logger.warning(
+                "SECURITY: Directory traversal '..' detected in relative path: %r",
+                relative_path
+            )
+            return False
+
+    return True

--- a/security.py
+++ b/security.py
@@ -215,6 +215,11 @@ def validate_relative_path(relative_path: str) -> bool:
         logger.warning("SECURITY: Null byte detected in relative path: %r", relative_path)
         return False
 
+    # Reject embedded CR/LF characters (can split entries in downstream file-list files)
+    if '\n' in relative_path or '\r' in relative_path:
+        logger.warning("SECURITY: Embedded CR/LF detected in relative path: %r", relative_path)
+        return False
+
     # Reject absolute paths
     if relative_path.startswith('/') or relative_path.startswith('\\'):
         logger.warning("SECURITY: Absolute path rejected as relative path: %r", relative_path)

--- a/security.py
+++ b/security.py
@@ -64,6 +64,9 @@ def validate_path_component(component: str) -> bool:
     Returns:
         True if the component is safe, False if it contains traversal patterns
     """
+    if not isinstance(component, str):
+        return False
+
     if not component or not component.strip():
         return False
 
@@ -201,6 +204,9 @@ def validate_relative_path(relative_path: str) -> bool:
     Returns:
         True if the relative path is safe, False otherwise
     """
+    if not isinstance(relative_path, str):
+        return False
+
     if not relative_path or not relative_path.strip():
         return False
 

--- a/services/backup_service.py
+++ b/services/backup_service.py
@@ -2,6 +2,11 @@
 """
 DragonCP Backup Service
 Handles backup restore, delete, reindex, and context-aware file matching operations
+
+SECURITY: All path operations in this service validate that constructed paths
+stay within the configured BACKUP_PATH and destination directories. Relative
+paths from API requests (restore file lists) are validated to prevent directory
+traversal. See security.py for the validation implementation.
 """
 
 import os
@@ -11,6 +16,13 @@ import subprocess
 import tempfile
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
+
+from security import (
+    assert_path_within_bounds,
+    validate_relative_path,
+    validate_resolved_path,
+    PathTraversalError,
+)
 
 
 class BackupService:
@@ -108,11 +120,36 @@ class BackupService:
           - Copy selected backup files into destination (rsync files-from)
         """
         try:
+            # SECURITY: Validate file list entries if provided.
+            # These are relative paths from the API request - must not contain
+            # traversal sequences or absolute paths.
+            if files:
+                for file_path in files:
+                    if not validate_relative_path(file_path):
+                        return False, f'Invalid file path rejected (possible path traversal): {file_path}'
+
             record = self.backup_model.get(backup_id)
             if not record:
                 return False, 'Backup not found'
             backup_path = record['backup_path']
             dest_path = record['dest_path']
+
+            # SECURITY: Validate backup_path is within BACKUP_PATH boundary
+            backup_base = self.config.get("BACKUP_PATH")
+            if backup_base:
+                if not validate_resolved_path(backup_path, [backup_base]):
+                    return False, 'Backup path is outside configured BACKUP_PATH boundary'
+
+            # SECURITY: Validate dest_path is within configured destination boundaries
+            allowed_dest_paths = [
+                self.config.get('MOVIE_DEST_PATH'),
+                self.config.get('TVSHOW_DEST_PATH'),
+                self.config.get('ANIME_DEST_PATH'),
+            ]
+            allowed_dest_paths = [p for p in allowed_dest_paths if p]
+            if allowed_dest_paths and dest_path:
+                if not validate_resolved_path(dest_path, allowed_dest_paths):
+                    return False, 'Destination path is outside configured directory boundaries'
             if not os.path.exists(backup_path):
                 return False, 'Backup directory not found on disk'
             if not os.path.exists(dest_path):

--- a/services/backup_service.py
+++ b/services/backup_service.py
@@ -124,10 +124,12 @@ class BackupService:
             # None = restore all; [] was already rejected at route level but
             # guard here too for defence-in-depth.
             if files is not None:
+                if not isinstance(files, list):
+                    return False, 'Invalid file selection; expected a list'
                 if len(files) == 0:
                     return False, 'Empty file selection not allowed'
                 for file_path in files:
-                    if not validate_relative_path(file_path):
+                    if not isinstance(file_path, str) or not validate_relative_path(file_path):
                         return False, f'Invalid file path rejected (possible path traversal): {file_path}'
 
             record = self.backup_model.get(backup_id)
@@ -153,6 +155,8 @@ class BackupService:
             allowed_dest_paths = [p for p in allowed_dest_paths if p]
             if not allowed_dest_paths and dest_path:
                 return False, 'No destination paths configured; refusing restore'
+            if allowed_dest_paths and not dest_path:
+                return False, 'Missing destination path for configured destination roots'
             if allowed_dest_paths and dest_path:
                 if not validate_resolved_path(dest_path, allowed_dest_paths):
                     return False, 'Destination path is outside configured directory boundaries'

--- a/services/backup_service.py
+++ b/services/backup_service.py
@@ -153,13 +153,12 @@ class BackupService:
                 self.config.get('ANIME_DEST_PATH'),
             ]
             allowed_dest_paths = [p for p in allowed_dest_paths if p]
-            if not allowed_dest_paths and dest_path:
+            if not allowed_dest_paths:
                 return False, 'No destination paths configured; refusing restore'
-            if allowed_dest_paths and not dest_path:
+            if not dest_path:
                 return False, 'Missing destination path for configured destination roots'
-            if allowed_dest_paths and dest_path:
-                if not validate_resolved_path(dest_path, allowed_dest_paths):
-                    return False, 'Destination path is outside configured directory boundaries'
+            if not validate_resolved_path(dest_path, allowed_dest_paths):
+                return False, 'Destination path is outside configured directory boundaries'
             if not os.path.exists(backup_path):
                 return False, 'Backup directory not found on disk'
             if not os.path.exists(dest_path):

--- a/services/backup_service.py
+++ b/services/backup_service.py
@@ -121,9 +121,11 @@ class BackupService:
         """
         try:
             # SECURITY: Validate file list entries if provided.
-            # These are relative paths from the API request - must not contain
-            # traversal sequences or absolute paths.
-            if files:
+            # None = restore all; [] was already rejected at route level but
+            # guard here too for defence-in-depth.
+            if files is not None:
+                if len(files) == 0:
+                    return False, 'Empty file selection not allowed'
                 for file_path in files:
                     if not validate_relative_path(file_path):
                         return False, f'Invalid file path rejected (possible path traversal): {file_path}'
@@ -134,11 +136,13 @@ class BackupService:
             backup_path = record['backup_path']
             dest_path = record['dest_path']
 
-            # SECURITY: Validate backup_path is within BACKUP_PATH boundary
+            # SECURITY: Fail closed — refuse restore if security boundaries
+            # cannot be established.
             backup_base = self.config.get("BACKUP_PATH")
-            if backup_base:
-                if not validate_resolved_path(backup_path, [backup_base]):
-                    return False, 'Backup path is outside configured BACKUP_PATH boundary'
+            if not backup_base:
+                return False, 'BACKUP_PATH is not configured; refusing restore'
+            if not validate_resolved_path(backup_path, [backup_base]):
+                return False, 'Backup path is outside configured BACKUP_PATH boundary'
 
             # SECURITY: Validate dest_path is within configured destination boundaries
             allowed_dest_paths = [
@@ -147,6 +151,8 @@ class BackupService:
                 self.config.get('ANIME_DEST_PATH'),
             ]
             allowed_dest_paths = [p for p in allowed_dest_paths if p]
+            if not allowed_dest_paths and dest_path:
+                return False, 'No destination paths configured; refusing restore'
             if allowed_dest_paths and dest_path:
                 if not validate_resolved_path(dest_path, allowed_dest_paths):
                     return False, 'Destination path is outside configured directory boundaries'

--- a/services/path_service.py
+++ b/services/path_service.py
@@ -251,7 +251,7 @@ class PathService:
         Returns:
             True if valid and within bounds, False otherwise
         """
-        if not dest_path:
+        if not isinstance(dest_path, str) or not dest_path:
             return False
 
         # Check for invalid characters

--- a/services/path_service.py
+++ b/services/path_service.py
@@ -271,11 +271,12 @@ class PathService:
             ]
             allowed_bases = [b for b in allowed_bases if b]
 
-        if allowed_bases:
-            return validate_resolved_path(dest_path, allowed_bases)
+        if not allowed_bases:
+            # SECURITY: Fail closed — no configured base paths means we cannot
+            # verify the path stays within bounds. Reject rather than allow.
+            return False
 
-        # No base paths configured - can only do basic validation
-        return True
+        return validate_resolved_path(dest_path, allowed_bases)
     
     def get_source_path_from_notification(
         self, 

--- a/services/path_service.py
+++ b/services/path_service.py
@@ -235,7 +235,7 @@ class PathService:
 
         return dest_path
     
-    def validate_destination_path(self, dest_path: str, media_type: str = None) -> bool:
+    def validate_destination_path(self, dest_path: str, media_type: Optional[str] = None) -> bool:
         """
         Validate that a destination path is valid and within configured bounds.
 

--- a/services/path_service.py
+++ b/services/path_service.py
@@ -3,10 +3,22 @@
 DragonCP Path Service
 Centralized service for constructing destination paths from source paths.
 Ensures consistency between dry-run validation and actual sync operations.
+
+SECURITY: All path construction methods in this service validate that the
+resulting paths stay within the configured directory boundaries. See
+security.py for the core validation functions. If you add new path
+construction methods, you MUST integrate bounds checking.
 """
 
 import os
 from typing import Optional, Tuple
+
+from security import (
+    assert_path_within_bounds,
+    validate_path_component,
+    validate_resolved_path,
+    PathTraversalError,
+)
 
 
 class PathService:
@@ -62,7 +74,12 @@ class PathService:
         
         # Combine to create destination path
         dest_path = os.path.join(dest_base, relative_structure)
-        
+
+        # SECURITY: Validate the constructed path stays within the destination base.
+        # This prevents path traversal via crafted source_path values from webhooks
+        # or API requests (e.g., source paths containing ".." sequences).
+        assert_path_within_bounds(dest_path, [dest_base])
+
         return dest_path
     
     def extract_relative_structure(self, source_path: str, media_type: str) -> str:
@@ -197,34 +214,67 @@ class PathService:
         dest_base = self.get_base_destination(media_type)
         if not dest_base:
             raise ValueError(f"Destination path not configured for media type: {media_type}")
-        
+
+        # SECURITY: Validate path components before constructing the full path.
+        # This prevents directory traversal via crafted folder_name or season_name
+        # from webhooks, API requests, or UI input.
+        if not validate_path_component(folder_name):
+            raise PathTraversalError(f"Invalid folder name: {folder_name}")
+        if season_name and not validate_path_component(season_name):
+            raise PathTraversalError(f"Invalid season name: {season_name}")
+
         if season_name:
             # Series/anime with season
             dest_path = os.path.join(dest_base, folder_name, season_name)
         else:
             # Movie or series folder
             dest_path = os.path.join(dest_base, folder_name)
-        
+
+        # SECURITY: Double-check resolved path stays within bounds
+        assert_path_within_bounds(dest_path, [dest_base])
+
         return dest_path
     
-    def validate_destination_path(self, dest_path: str) -> bool:
+    def validate_destination_path(self, dest_path: str, media_type: str = None) -> bool:
         """
-        Validate that a destination path is valid.
-        
+        Validate that a destination path is valid and within configured bounds.
+
+        SECURITY: This method checks both basic validity (non-empty, no null bytes)
+        AND path boundary enforcement (the path must resolve within the configured
+        destination directory for the given media type, or within any destination
+        directory if media_type is not specified).
+
         Args:
             dest_path: Destination path to validate
-        
+            media_type: Optional media type for stricter base path checking
+
         Returns:
-            True if valid, False otherwise
+            True if valid and within bounds, False otherwise
         """
         if not dest_path:
             return False
-        
-        # Check for invalid characters (though os.path.join should handle most)
-        # On Linux, most characters are valid except null byte
+
+        # Check for invalid characters
         if '\0' in dest_path:
             return False
-        
+
+        # SECURITY: Validate the path stays within configured destination boundaries
+        if media_type:
+            dest_base = self.get_base_destination(media_type)
+            allowed_bases = [dest_base] if dest_base else []
+        else:
+            # Check against all configured destination paths
+            allowed_bases = [
+                self.config.get("MOVIE_DEST_PATH"),
+                self.config.get("TVSHOW_DEST_PATH"),
+                self.config.get("ANIME_DEST_PATH"),
+            ]
+            allowed_bases = [b for b in allowed_bases if b]
+
+        if allowed_bases:
+            return validate_resolved_path(dest_path, allowed_bases)
+
+        # No base paths configured - can only do basic validation
         return True
     
     def get_source_path_from_notification(

--- a/services/rename_service.py
+++ b/services/rename_service.py
@@ -7,6 +7,12 @@ This service is isolated from the sync/transfer logic because:
 - Rename operations are local filesystem operations only (no rsync/SSH)
 - Immediate execution, no queue management needed
 - Simple os.rename() vs complex transfer coordination
+
+SECURITY: This service performs direct filesystem operations (os.rename,
+os.makedirs) using paths derived from webhook payloads. All constructed
+paths are validated through security.assert_path_within_bounds() before
+any filesystem operation to prevent directory traversal attacks.
+See security.py for the validation implementation.
 """
 
 import os
@@ -15,6 +21,7 @@ from datetime import datetime
 from typing import Dict, List, Tuple, Optional
 
 from services.path_service import PathService
+from security import assert_path_within_bounds, validate_relative_path, PathTraversalError
 
 
 class RenameService:
@@ -346,6 +353,14 @@ class RenameService:
                         print(f"   {log_msg}")
                         operation_logs.append(log_msg)
                         
+            except PathTraversalError as e:
+                # SECURITY: Path traversal attempt detected in webhook rename data
+                result['status'] = 'failed'
+                result['message'] = 'Path traversal rejected'
+                result['error'] = f"Security: {str(e)}"
+                log_msg = f"SECURITY: Path traversal blocked for {result['previous_name']}: {e}"
+                print(f"   {log_msg}")
+                operation_logs.append(log_msg)
             except PermissionError as e:
                 result['status'] = 'failed'
                 result['message'] = 'Permission denied'
@@ -375,37 +390,51 @@ class RenameService:
     def _map_to_local_path(self, relative_path: str, server_series_path: str, media_type: str) -> str:
         """
         Convert a server relative path to a local filesystem path.
-        
+
         Example:
             relative_path: "Season 01/Show - S01E01 - Title.mkv"
             server_series_path: "/home/dragondb/media/TV Shows/Show Name (2025)"
             media_type: "tvshows"
-            
+
             Result: "{TVSHOW_DEST_PATH}/Show Name (2025)/Season 01/Show - S01E01 - Title.mkv"
-        
+
         Args:
             relative_path: Relative path from Sonarr (e.g., "Season 01/filename.mkv")
             server_series_path: Full server path to series folder
             media_type: 'tvshows' or 'anime'
-        
+
         Returns:
             Full local filesystem path
+
+        Raises:
+            PathTraversalError: If the constructed path escapes the destination directory
         """
+        # SECURITY: Validate the relative path from webhook doesn't contain traversal
+        if not validate_relative_path(relative_path):
+            raise PathTraversalError(
+                f"Invalid relative path from webhook: {relative_path}"
+            )
+
         # Get the series folder name from the server path
         series_folder_name = os.path.basename(server_series_path.rstrip('/'))
-        
+
         # Get the local base destination path for this media type
         dest_base = self.path_service.get_base_destination(media_type)
         if not dest_base:
             raise ValueError(f"Destination path not configured for media type: {media_type}")
-        
+
         # Normalize path separators for the current OS
         # Sonarr sends paths with forward slashes, but we need OS-appropriate separators
         relative_path_normalized = relative_path.replace('/', os.sep).replace('\\', os.sep)
-        
+
         # Construct the full local path
         local_path = os.path.join(dest_base, series_folder_name, relative_path_normalized)
-        
+
+        # SECURITY: Validate the constructed path stays within the destination base.
+        # This is the critical check that prevents directory traversal via crafted
+        # relative paths from webhook payloads (e.g., "../../etc/passwd").
+        assert_path_within_bounds(local_path, [dest_base])
+
         return local_path
 
     def _extract_verification_files(self, notification: Dict) -> List[Dict]:

--- a/services/rename_service.py
+++ b/services/rename_service.py
@@ -460,21 +460,42 @@ class RenameService:
         previous_name = file_info.get('previous_name') or os.path.basename(file_info.get('previous_path', ''))
         new_name = file_info.get('new_name') or os.path.basename(file_info.get('new_path', ''))
 
+        def _traversal_failure(msg):
+            """Build a failed verification result for path traversal rejections."""
+            return {
+                'previous_name': previous_name,
+                'expected_name': new_name,
+                'local_previous_path': None,
+                'local_expected_path': None,
+                'actual_name': None,
+                'actual_path': None,
+                'status': 'failed',
+                'message': msg,
+            }
+
         local_previous_path = file_info.get('local_previous_path')
         if not local_previous_path and file_info.get('previous_relative_path'):
-            local_previous_path = self._map_to_local_path(
-                file_info['previous_relative_path'],
-                server_series_path,
-                media_type,
-            )
+            try:
+                local_previous_path = self._map_to_local_path(
+                    file_info['previous_relative_path'],
+                    server_series_path,
+                    media_type,
+                )
+            except PathTraversalError as e:
+                # SECURITY: Path traversal in verification — record as failed
+                return _traversal_failure(f'Path traversal rejected: {e}')
 
         local_new_path = file_info.get('local_new_path')
         if not local_new_path and file_info.get('new_relative_path'):
-            local_new_path = self._map_to_local_path(
-                file_info['new_relative_path'],
-                server_series_path,
-                media_type,
-            )
+            try:
+                local_new_path = self._map_to_local_path(
+                    file_info['new_relative_path'],
+                    server_series_path,
+                    media_type,
+                )
+            except PathTraversalError as e:
+                # SECURITY: Path traversal in verification — record as failed
+                return _traversal_failure(f'Path traversal rejected: {e}')
 
         result = {
             'previous_name': previous_name,

--- a/services/transfer_service.py
+++ b/services/transfer_service.py
@@ -22,7 +22,34 @@ class TransferService:
         self.socketio = socketio
         self.queue_manager = queue_manager
         self.transfers = {}  # Active transfer processes: {transfer_id: process}
-    
+
+    def _build_ssh_host_key_options(self) -> List[str]:
+        """
+        SECURITY (SEC-07): Build rsync's `ssh -o ...` host-key options from the
+        configured policy, mirroring the paramiko path in ssh.py so both agree.
+
+        - strict     -> StrictHostKeyChecking=yes + managed UserKnownHostsFile
+        - accept-new -> StrictHostKeyChecking=accept-new + managed UserKnownHostsFile
+                        (trust-on-first-use; a changed key is rejected)
+        - no         -> StrictHostKeyChecking=no (legacy insecure)
+        """
+        # Imported here to avoid any import-order coupling at module load.
+        from ssh import normalize_host_key_policy, resolve_known_hosts_file
+
+        policy = normalize_host_key_policy(self.config.get("SSH_HOST_KEY_CHECKING"))
+        if policy == "no":
+            print("⚠️  SSH host-key verification DISABLED for rsync (SSH_HOST_KEY_CHECKING=no) "
+                  "- vulnerable to MITM")
+            return ["-o", "StrictHostKeyChecking=no"]
+
+        known_hosts = resolve_known_hosts_file(self.config.get("SSH_KNOWN_HOSTS_FILE"))
+        strict_val = "yes" if policy == "strict" else "accept-new"
+        # NOTE: the path is embedded in rsync's single -e string (space-split by
+        # rsync), so it must not contain spaces. The default app-dir path is safe.
+        return ["-o", f"StrictHostKeyChecking={strict_val}",
+                "-o", f"UserKnownHostsFile={known_hosts}"]
+
+
     def perform_dry_run_rsync(self, source_path: str, dest_path: str) -> Dict:
         """
         Perform rsync dry-run to validate sync safety
@@ -65,7 +92,8 @@ class TransferService:
                     ssh_key_path = ""
             
             # Build SSH options
-            ssh_options = ["-o", "StrictHostKeyChecking=no", "-o", "Compression=no"]
+            # SECURITY (SEC-07): host-key verification per configured policy
+            ssh_options = self._build_ssh_host_key_options() + ["-o", "Compression=no"]
             if ssh_key_path and os.path.exists(ssh_key_path):
                 ssh_options.extend(["-i", ssh_key_path])
             
@@ -359,7 +387,8 @@ class TransferService:
                 print("🧪 TEST_MODE enabled - rsync will run in dry-run mode (no actual file transfers)")
             
             # Build SSH options for rsync
-            ssh_options = ["-o", "StrictHostKeyChecking=no", "-o", "Compression=no"]
+            # SECURITY (SEC-07): host-key verification per configured policy
+            ssh_options = self._build_ssh_host_key_options() + ["-o", "Compression=no"]
             if ssh_key_path and os.path.exists(ssh_key_path):
                 ssh_options.extend(["-i", ssh_key_path])
             

--- a/services/transfer_service.py
+++ b/services/transfer_service.py
@@ -34,7 +34,11 @@ class TransferService:
         - no         -> StrictHostKeyChecking=no (legacy insecure)
         """
         # Imported here to avoid any import-order coupling at module load.
-        from ssh import normalize_host_key_policy, resolve_known_hosts_file
+        from ssh import (
+            normalize_host_key_policy,
+            resolve_known_hosts_file,
+            _ensure_known_hosts_file,
+        )
 
         policy = normalize_host_key_policy(self.config.get("SSH_HOST_KEY_CHECKING"))
         if policy == "no":
@@ -43,6 +47,12 @@ class TransferService:
             return ["-o", "StrictHostKeyChecking=no"]
 
         known_hosts = resolve_known_hosts_file(self.config.get("SSH_KNOWN_HOSTS_FILE"))
+        # Ensure the managed known_hosts file (and its parent) exist so rsync's
+        # ssh can read it (strict) and persist first-seen keys (accept-new). This
+        # is the SAME file the paramiko browse path loads, keeping both consistent.
+        if not _ensure_known_hosts_file(known_hosts):
+            print(f"⚠️  Could not prepare known_hosts file {known_hosts}; "
+                  "rsync host-key verification may be unreliable")
         strict_val = "yes" if policy == "strict" else "accept-new"
         # NOTE: the path is embedded in rsync's single -e string (space-split by
         # rsync), so it must not contain spaces. The default app-dir path is safe.

--- a/ssh.py
+++ b/ssh.py
@@ -2,30 +2,155 @@
 """
 DragonCP SSH Manager
 Handles SSH connections and remote operations
+
+=== SECURITY BOUNDARY - REMOTE COMMAND INJECTION ===
+
+Remote commands are built as shell strings and run via exec_command(). Any
+path segment interpolated into a command MUST be shell-quoted with
+shlex.quote() so that quotes, backticks, `$`, `;`, and other metacharacters in
+folder/season/episode names (which are legitimate in media filenames, or may
+come from an untrusted remote listing) cannot break out of the intended
+argument and execute a second command on the SSH target.
+
+Do NOT interpolate a raw path into a command string. Always pass it through
+self._quote_remote_path(). See also security.py (path-component validation)
+and webhook_auth.py (webhook authentication).
 """
 
 import os
+import shlex
+import logging
 import paramiko
-from typing import List, Dict, Tuple
+from typing import List, Dict, Tuple, Optional
+
+logger = logging.getLogger(__name__)
+
+# ===== SSH HOST-KEY VERIFICATION (SEC-07) =====
+#
+# Host-key checking is configurable via SSH_HOST_KEY_CHECKING:
+#   - "strict"      -> reject unknown hosts (paramiko RejectPolicy / ssh yes).
+#                      Most secure; requires the host key to be pre-provisioned
+#                      in the known_hosts file.
+#   - "accept-new"  -> trust-on-first-use (DEFAULT). Unknown hosts are added and
+#                      persisted; a later key CHANGE is rejected as a possible
+#                      MITM. Secure default that stays usable on first connect.
+#   - "no"          -> legacy insecure behaviour: accept any key (vulnerable to
+#                      MITM). Only for users who cannot manage known_hosts.
+#
+# The paramiko (browsing) and rsync (transfer) paths share these helpers so both
+# consult/persist the SAME known_hosts file and agree on the policy.
+
+DEFAULT_KNOWN_HOSTS_FILENAME = "dragoncp_known_hosts"
+VALID_HOST_KEY_POLICIES = ("strict", "accept-new", "no")
+
+
+def normalize_host_key_policy(configured: Optional[str]) -> str:
+    """Normalise the SSH_HOST_KEY_CHECKING value to a canonical policy string."""
+    policy = (configured or "").strip().lower()
+    if policy in ("strict", "yes"):
+        return "strict"
+    if policy in ("accept-new", "acceptnew", "tofu"):
+        return "accept-new"
+    if policy in ("no", "off", "none", "false", "disable", "disabled"):
+        return "no"
+    if policy:
+        logger.warning(
+            "SSH: unrecognised SSH_HOST_KEY_CHECKING=%r; defaulting to 'accept-new'",
+            configured,
+        )
+    return "accept-new"
+
+
+def resolve_known_hosts_file(configured: Optional[str] = None) -> str:
+    """
+    Resolve the known_hosts file path used for host-key verification.
+
+    Defaults to <app_dir>/dragoncp_known_hosts so the app owns a managed
+    known_hosts file independent of the invoking user's ~/.ssh.
+    """
+    if configured and configured.strip():
+        return os.path.abspath(os.path.expanduser(configured.strip()))
+    app_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(app_dir, DEFAULT_KNOWN_HOSTS_FILENAME)
+
+
+def _ensure_known_hosts_file(path: str) -> bool:
+    """Ensure the known_hosts file (and its parent dir) exist so keys persist."""
+    try:
+        parent = os.path.dirname(path)
+        if parent and not os.path.isdir(parent):
+            os.makedirs(parent, exist_ok=True)
+        if not os.path.exists(path):
+            open(path, 'a').close()
+        return True
+    except OSError as e:
+        logger.warning("SSH: could not create known_hosts file %s: %s", path, e)
+        return False
 
 
 class SSHManager:
     """SSH connection manager"""
     
-    def __init__(self, host: str, username: str, password: str = None, key_path: str = None):
+    def __init__(self, host: str, username: str, password: str = None, key_path: str = None,
+                 host_key_policy: str = "accept-new", known_hosts_file: str = None):
         self.host = host
         self.username = username
         self.password = password
         self.key_path = key_path
+        # SECURITY (SEC-07): host-key verification policy and managed known_hosts file
+        self.host_key_policy = normalize_host_key_policy(host_key_policy)
+        self.known_hosts_file = resolve_known_hosts_file(known_hosts_file)
         self.client = None
         self.connected = False
-    
+
+    def _apply_host_key_policy(self):
+        """
+        SECURITY (SEC-07): Configure host-key verification on self.client.
+
+        Loads known host keys (so a CHANGED key is detected as a possible MITM)
+        and applies the configured missing-host-key policy. In "no" mode we skip
+        loading entirely to preserve the legacy accept-anything behaviour.
+        """
+        if self.host_key_policy == "no":
+            logger.warning(
+                "SSH: host-key verification is DISABLED (SSH_HOST_KEY_CHECKING=no) for %s. "
+                "The connection is vulnerable to man-in-the-middle attacks. "
+                "Set SSH_HOST_KEY_CHECKING=accept-new (default) or strict.",
+                self.host,
+            )
+            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            return
+
+        # Load system + managed known_hosts so previously-seen keys are trusted
+        # and any key change raises BadHostKeyException.
+        try:
+            self.client.load_system_host_keys()
+        except Exception as e:
+            logger.debug("SSH: load_system_host_keys failed (non-fatal): %s", e)
+
+        if _ensure_known_hosts_file(self.known_hosts_file):
+            try:
+                # load_host_keys() also sets the persistence target so that
+                # AutoAddPolicy writes newly-accepted keys back to this file.
+                self.client.load_host_keys(self.known_hosts_file)
+            except (IOError, OSError) as e:
+                logger.warning(
+                    "SSH: could not load known_hosts %s: %s", self.known_hosts_file, e
+                )
+
+        if self.host_key_policy == "strict":
+            # Reject any host not already present in known_hosts.
+            self.client.set_missing_host_key_policy(paramiko.RejectPolicy())
+        else:  # accept-new (trust-on-first-use, persists accepted keys)
+            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
     def connect(self) -> bool:
         """Establish SSH connection"""
         try:
             self.client = paramiko.SSHClient()
-            self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-            
+            # SECURITY (SEC-07): apply configured host-key verification policy
+            self._apply_host_key_policy()
+
             if self.key_path and os.path.exists(self.key_path):
                 private_key = paramiko.RSAKey.from_private_key_file(self.key_path)
                 self.client.connect(
@@ -44,17 +169,68 @@ class SSHManager:
             
             self.connected = True
             return True
+        except paramiko.BadHostKeyException as e:
+            # SECURITY (SEC-07): the server presented a key that does NOT match
+            # the one recorded in known_hosts — a strong MITM indicator.
+            logger.error(
+                "SSH: HOST KEY MISMATCH for %s — the server's key changed and does "
+                "not match known_hosts. Possible man-in-the-middle. %s", self.host, e
+            )
+            print(f"SSH connection failed: host key verification FAILED for {self.host} "
+                  f"(possible MITM). Remove the stale entry from '{self.known_hosts_file}' "
+                  f"only if you trust the new key.")
+            self.connected = False
+            return False
+        except paramiko.SSHException as e:
+            # RejectPolicy raises SSHException ("Server ... not found in known_hosts")
+            # under strict mode for an unknown host.
+            if self.host_key_policy == "strict" and "known_hosts" in str(e).lower():
+                logger.error(
+                    "SSH: host %s is not in known_hosts and SSH_HOST_KEY_CHECKING=strict. "
+                    "Add its key to '%s' (e.g. ssh-keyscan) or use accept-new. %s",
+                    self.host, self.known_hosts_file, e
+                )
+                print(f"SSH connection failed: host {self.host} not in known_hosts "
+                      f"(strict mode). Provision its key in '{self.known_hosts_file}'.")
+            else:
+                print(f"SSH connection failed: {e}")
+            self.connected = False
+            return False
         except Exception as e:
             print(f"SSH connection failed: {e}")
             self.connected = False
             return False
-    
+
     def disconnect(self):
         """Close SSH connection"""
         if self.client:
             self.client.close()
         self.connected = False
     
+    @staticmethod
+    def _quote_remote_path(path: str) -> str:
+        """
+        Shell-quote a remote path for safe interpolation into a command string.
+
+        SECURITY: This is the mandatory boundary that prevents remote command
+        injection. shlex.quote() wraps the value so that any shell metacharacter
+        (", ', `, $, ;, &, |, newline, space, ...) is treated as literal data
+        rather than shell syntax. This preserves legitimate media names that
+        contain such characters while making injection impossible.
+
+        Args:
+            path: The remote filesystem path to quote
+
+        Returns:
+            A safely quoted shell token
+
+        Raises:
+            ValueError: If path is not a non-empty string
+        """
+        if not isinstance(path, str) or not path:
+            raise ValueError("Remote path must be a non-empty string")
+        return shlex.quote(path)
+
     def execute_command(self, command: str) -> Tuple[int, str, str]:
         """Execute command on remote server"""
         if not self.connected:
@@ -71,10 +247,10 @@ class SSHManager:
     
     def list_folders(self, path: str) -> List[str]:
         """List folders in remote directory"""
-        # Fix escape sequence warning by using raw string
-        command = f'find "{path}" -mindepth 1 -maxdepth 1 -type d -exec basename "{{}}" \\;'
+        # SECURITY: quote the path to prevent remote command injection
+        command = f'find {self._quote_remote_path(path)} -mindepth 1 -maxdepth 1 -type d -exec basename "{{}}" \\;'
         exit_code, output, error = self.execute_command(command)
-        
+
         if exit_code == 0 and output:
             folders = [f.strip() for f in output.split('\n') if f.strip()]
             return sorted(folders, key=lambda x: (len(x), x))
@@ -83,7 +259,8 @@ class SSHManager:
     def list_folders_with_metadata(self, path: str) -> List[Dict]:
         """List folders in remote directory with metadata including most recent file modification time"""
         # Get folder names with most recent file modification time within each folder
-        command = f'''find "{path}" -mindepth 1 -maxdepth 1 -type d -exec sh -c '
+        # SECURITY: quote the path to prevent remote command injection
+        command = f'''find {self._quote_remote_path(path)} -mindepth 1 -maxdepth 1 -type d -exec sh -c '
             for dir; do
                 # Get the most recent file modification time within this folder (recursive)
                 latest_file_time=$(find "$dir" -type f -printf "%T@\\n" | sort -nr | head -1)
@@ -119,8 +296,8 @@ class SSHManager:
     
     def list_files(self, path: str) -> List[str]:
         """List files in remote directory"""
-        # Fix escape sequence warning by using raw string
-        command = f'find "{path}" -maxdepth 1 -type f -exec basename "{{}}" \\;'
+        # SECURITY: quote the path to prevent remote command injection
+        command = f'find {self._quote_remote_path(path)} -maxdepth 1 -type f -exec basename "{{}}" \\;'
         exit_code, output, error = self.execute_command(command)
         
         if exit_code == 0 and output:
@@ -130,7 +307,8 @@ class SSHManager:
 
     def list_files_with_metadata(self, path: str) -> List[Dict]:
         """List files in remote directory with metadata including modification time and size"""
-        command = f'''find "{path}" -maxdepth 1 -type f -exec sh -c '
+        # SECURITY: quote the path to prevent remote command injection
+        command = f'''find {self._quote_remote_path(path)} -maxdepth 1 -type f -exec sh -c '
             for file; do
                 filename=$(basename "$file")
                 mod_time=$(stat -c %Y "$file")
@@ -166,7 +344,8 @@ class SSHManager:
 
     def get_folder_file_summary(self, path: str) -> Dict:
         """Get summary of files in a folder including count, total size, and most recent modification"""
-        command = f'''find "{path}" -type f -exec sh -c '
+        # SECURITY: quote the path to prevent remote command injection
+        command = f'''find {self._quote_remote_path(path)} -type f -exec sh -c '
             total_size=0
             latest_time=0
             file_count=0

--- a/ssh.py
+++ b/ssh.py
@@ -107,9 +107,10 @@ class SSHManager:
         """
         SECURITY (SEC-07): Configure host-key verification on self.client.
 
-        Loads known host keys (so a CHANGED key is detected as a possible MITM)
-        and applies the configured missing-host-key policy. In "no" mode we skip
-        loading entirely to preserve the legacy accept-anything behaviour.
+        Loads the app-managed known_hosts file (so a CHANGED key is detected as a
+        possible MITM) and applies the configured missing-host-key policy. In "no"
+        mode we skip loading entirely to preserve the legacy accept-anything
+        behaviour.
         """
         if self.host_key_policy == "no":
             logger.warning(
@@ -121,13 +122,12 @@ class SSHManager:
             self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             return
 
-        # Load system + managed known_hosts so previously-seen keys are trusted
-        # and any key change raises BadHostKeyException.
-        try:
-            self.client.load_system_host_keys()
-        except Exception as e:
-            logger.debug("SSH: load_system_host_keys failed (non-fatal): %s", e)
-
+        # Load ONLY the app-managed known_hosts file — deliberately NOT the
+        # invoking user's ~/.ssh/known_hosts. The rsync transfer path
+        # (transfer_service.py) passes this same file via UserKnownHostsFile, so
+        # trusting an extra system source here would let browsing accept a host
+        # that rsync then rejects (e.g. under strict mode). Recorded keys are
+        # trusted; a changed key raises BadHostKeyException.
         if _ensure_known_hosts_file(self.known_hosts_file):
             try:
                 # load_host_keys() also sets the persistence target so that

--- a/webhook_auth.py
+++ b/webhook_auth.py
@@ -401,8 +401,19 @@ def require_webhook_auth(f):
                     "code": "WEBHOOK_AUTH_FAILED"
                 }), 403
 
-        # Fallback (should not reach here, but safety net)
-        return f(*args, **kwargs)
+        # Fallback — fail closed. This branch should be unreachable given the
+        # four cases above cover all (has_secret, has_ips) combinations. If we
+        # somehow land here, refuse the request rather than allowing it through.
+        logger.error(
+            "WEBHOOK_AUTH: Unexpected auth state reached (secret=%s, ips=%s). "
+            "Failing closed. Endpoint: %s",
+            has_secret, has_ips, request.path
+        )
+        return jsonify({
+            "status": "error",
+            "message": "Internal webhook authentication error",
+            "code": "WEBHOOK_AUTH_ERROR"
+        }), 500
 
     return decorated_function
 

--- a/webhook_auth.py
+++ b/webhook_auth.py
@@ -56,6 +56,9 @@ def _load_env_file() -> Dict[str, str]:
     config = {}
     script_dir = os.path.dirname(os.path.abspath(__file__))
 
+    # Read both files and merge: dragoncp_env.env is the base, .env overrides.
+    # If a file exists but cannot be read, fail closed by raising so the caller
+    # never silently falls through to the unauthenticated allow-all path.
     env_files = [
         os.path.join(script_dir, 'dragoncp_env.env'),
         os.path.join(script_dir, '.env'),
@@ -70,9 +73,15 @@ def _load_env_file() -> Dict[str, str]:
                         if line and not line.startswith('#') and '=' in line:
                             key, value = line.split('=', 1)
                             config[key.strip()] = value.strip().strip('"').strip("'")
-                break
             except Exception as e:
-                logger.error("Error loading webhook config from %s: %s", env_file, e)
+                logger.error(
+                    "WEBHOOK_AUTH: Failed to load config from %s: %s. "
+                    "Failing closed — webhook auth cannot be determined.",
+                    env_file, e
+                )
+                raise RuntimeError(
+                    f"Webhook auth config load failed for {env_file}: {e}"
+                ) from e
 
     return config
 
@@ -191,7 +200,7 @@ def verify_webhook_signature(payload_bytes: bytes, signature_header: str, secret
     Returns:
         True if signature is valid, False otherwise
     """
-    if not payload_bytes or not signature_header or not secret:
+    if payload_bytes is None or not signature_header or not secret:
         return False
 
     # Parse the signature header - expected format: "sha256=<hex_digest>"

--- a/webhook_auth.py
+++ b/webhook_auth.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""
+DragonCP Webhook Authentication Module
+
+Provides HMAC signature verification and source IP whitelisting for
+webhook receiver endpoints (/api/webhook/movies, /api/webhook/series,
+/api/webhook/anime).
+
+Authentication Logic Matrix:
+┌─────────────────┬───────────────────┬──────────────────────────────────────────────┐
+│ WEBHOOK_SECRET  │ WEBHOOK_ALLOWED_IPS│ Behavior                                     │
+├─────────────────┼───────────────────┼──────────────────────────────────────────────┤
+│ Not set         │ Not set           │ Allow all + WARNING log (backward compat)    │
+│ Not set         │ Set               │ IP check only - whitelisted pass, else 403   │
+│ Set             │ Not set           │ Signature check only - valid sig or 401      │
+│ Set             │ Set               │ Either passes - valid IP OR valid sig         │
+└─────────────────┴───────────────────┴──────────────────────────────────────────────┘
+
+Backward Compatibility:
+    If neither WEBHOOK_SECRET nor WEBHOOK_ALLOWED_IPS is configured, all
+    requests are allowed through with a warning log. This prevents breaking
+    existing setups on upgrade.
+
+IP Whitelisting Safety:
+    IP whitelisting is safe for DragonCP's private-network deployment model
+    (Tailscale/LAN). TCP handshake prevents IP spoofing. For internet-facing
+    deployments, HMAC signature verification should be the primary mechanism
+    with IP whitelisting as a supplementary layer.
+"""
+
+import os
+import hmac
+import hashlib
+import ipaddress
+import functools
+import logging
+from typing import Dict, List, Optional
+
+from flask import request, jsonify
+
+logger = logging.getLogger(__name__)
+
+# ===== CONFIGURATION =====
+
+# Cache for loaded webhook config
+_webhook_config_cache: Optional[Dict[str, str]] = None
+# Track whether we've logged the auth status at startup
+_auth_status_logged = False
+
+
+def _load_env_file() -> Dict[str, str]:
+    """
+    Load configuration from dragoncp_env.env or .env file.
+    Mirrors the pattern from auth.py to avoid circular imports.
+    """
+    config = {}
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+
+    env_files = [
+        os.path.join(script_dir, 'dragoncp_env.env'),
+        os.path.join(script_dir, '.env'),
+    ]
+
+    for env_file in env_files:
+        if os.path.exists(env_file):
+            try:
+                with open(env_file, 'r') as f:
+                    for line in f:
+                        line = line.strip()
+                        if line and not line.startswith('#') and '=' in line:
+                            key, value = line.split('=', 1)
+                            config[key.strip()] = value.strip().strip('"').strip("'")
+                break
+            except Exception as e:
+                logger.error("Error loading webhook config from %s: %s", env_file, e)
+
+    return config
+
+
+def _get_webhook_config() -> Dict[str, Optional[str]]:
+    """
+    Get webhook authentication configuration.
+
+    Returns:
+        Dict with 'secret' and 'allowed_ips' keys.
+        Values are None if not configured.
+    """
+    global _webhook_config_cache
+
+    if _webhook_config_cache is not None:
+        return _webhook_config_cache
+
+    env_config = _load_env_file()
+
+    secret = (
+        env_config.get('WEBHOOK_SECRET')
+        or os.environ.get('WEBHOOK_SECRET')
+    ) or None
+
+    allowed_ips_raw = (
+        env_config.get('WEBHOOK_ALLOWED_IPS')
+        or os.environ.get('WEBHOOK_ALLOWED_IPS')
+    ) or None
+
+    _webhook_config_cache = {
+        'secret': secret if secret else None,
+        'allowed_ips_raw': allowed_ips_raw if allowed_ips_raw else None,
+    }
+
+    return _webhook_config_cache
+
+
+def _parse_allowed_ips(raw: str) -> List:
+    """
+    Parse comma-separated IP addresses and CIDR ranges.
+
+    Supports:
+        - Individual IPs: "192.168.1.100"
+        - CIDR ranges: "192.168.1.0/24"
+        - IPv6: "::1", "fd00::/8"
+        - Mixed: "192.168.1.100,10.0.0.0/24,::1"
+
+    Args:
+        raw: Comma-separated string of IPs/CIDRs
+
+    Returns:
+        List of ipaddress.IPv4Network/IPv6Network objects
+    """
+    networks = []
+    for entry in raw.split(','):
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            # Try parsing as a network (CIDR notation)
+            # strict=False allows host bits set (e.g., 192.168.1.100/24)
+            network = ipaddress.ip_network(entry, strict=False)
+            networks.append(network)
+        except ValueError:
+            logger.warning(
+                "WEBHOOK_AUTH: Invalid IP/CIDR entry ignored: '%s'", entry
+            )
+    return networks
+
+
+def is_ip_allowed(client_ip: str, allowed_networks: List) -> bool:
+    """
+    Check if a client IP is within any of the allowed networks.
+
+    Args:
+        client_ip: The client's IP address string
+        allowed_networks: List of ipaddress network objects from _parse_allowed_ips()
+
+    Returns:
+        True if the IP is in any allowed network, False otherwise
+    """
+    if not client_ip or not allowed_networks:
+        return False
+
+    try:
+        addr = ipaddress.ip_address(client_ip)
+    except ValueError:
+        logger.warning(
+            "WEBHOOK_AUTH: Could not parse client IP: '%s'", client_ip
+        )
+        return False
+
+    for network in allowed_networks:
+        try:
+            if addr in network:
+                return True
+        except TypeError:
+            # IPv4 address checked against IPv6 network or vice versa
+            continue
+
+    return False
+
+
+def verify_webhook_signature(payload_bytes: bytes, signature_header: str, secret: str) -> bool:
+    """
+    Verify HMAC-SHA256 signature of webhook payload.
+
+    The signature header format is: "sha256=<hex_digest>"
+    This follows the convention used by GitHub, GitLab, and other webhook providers.
+
+    Args:
+        payload_bytes: Raw request body bytes
+        signature_header: Value of X-DragonCP-Signature header
+        secret: The shared HMAC secret
+
+    Returns:
+        True if signature is valid, False otherwise
+    """
+    if not payload_bytes or not signature_header or not secret:
+        return False
+
+    # Parse the signature header - expected format: "sha256=<hex_digest>"
+    if not signature_header.startswith('sha256='):
+        logger.warning(
+            "WEBHOOK_AUTH: Invalid signature format (expected 'sha256=...'): %s",
+            signature_header[:20]
+        )
+        return False
+
+    provided_signature = signature_header[7:]  # Strip "sha256=" prefix
+
+    # Compute expected signature
+    expected_signature = hmac.new(
+        secret.encode('utf-8'),
+        payload_bytes,
+        hashlib.sha256
+    ).hexdigest()
+
+    # Constant-time comparison to prevent timing attacks
+    return hmac.compare_digest(provided_signature, expected_signature)
+
+
+def _log_auth_status():
+    """
+    Log the webhook authentication status at startup/first use.
+    Called once to inform the operator of the current security posture.
+    """
+    global _auth_status_logged
+
+    if _auth_status_logged:
+        return
+
+    _auth_status_logged = True
+
+    config = _get_webhook_config()
+    has_secret = config['secret'] is not None
+    has_ips = config['allowed_ips_raw'] is not None
+
+    if not has_secret and not has_ips:
+        logger.warning(
+            "WEBHOOK_AUTH: Webhook endpoints are UNAUTHENTICATED. "
+            "Configure WEBHOOK_SECRET and/or WEBHOOK_ALLOWED_IPS in "
+            "dragoncp_env.env for security."
+        )
+        print(
+            "WARNING: Webhook endpoints are UNAUTHENTICATED. "
+            "Configure WEBHOOK_SECRET and/or WEBHOOK_ALLOWED_IPS in "
+            "dragoncp_env.env for security."
+        )
+    elif has_ips and not has_secret:
+        networks = _parse_allowed_ips(config['allowed_ips_raw'])
+        logger.info(
+            "WEBHOOK_AUTH: IP whitelist enabled (%d entries). "
+            "No HMAC signature verification configured.",
+            len(networks)
+        )
+        print(f"Webhook auth: IP whitelist enabled ({len(networks)} entries)")
+    elif has_secret and not has_ips:
+        logger.info(
+            "WEBHOOK_AUTH: HMAC signature verification enabled (X-DragonCP-Signature). "
+            "No IP whitelist configured."
+        )
+        print("Webhook auth: HMAC signature verification enabled")
+    else:
+        networks = _parse_allowed_ips(config['allowed_ips_raw'])
+        logger.info(
+            "WEBHOOK_AUTH: Defense-in-depth enabled - HMAC signature + "
+            "IP whitelist (%d entries). Request passes if EITHER check succeeds.",
+            len(networks)
+        )
+        print(f"Webhook auth: HMAC signature + IP whitelist ({len(networks)} entries)")
+
+
+def require_webhook_auth(f):
+    """
+    Decorator for webhook receiver endpoints that enforces authentication
+    based on the configured WEBHOOK_SECRET and/or WEBHOOK_ALLOWED_IPS.
+
+    This decorator MUST be applied to all webhook receiver endpoints
+    (POST /api/webhook/movies, /api/webhook/series, /api/webhook/anime).
+    Place it AFTER @route() and BEFORE the function definition.
+
+    Authentication matrix (see module docstring for full table):
+    - Neither configured: allow all with warning (backward compatible)
+    - IP only: whitelist check
+    - Secret only: signature check
+    - Both: either passes (OR logic)
+
+    Note on request.get_data():
+        This decorator calls request.get_data() to capture raw bytes for HMAC
+        verification. Flask caches the raw data internally, so subsequent calls
+        to request.json in the route handler still work correctly.
+
+    Note on reverse proxy:
+        Client IP is read from request.remote_addr. If DragonCP is deployed
+        behind a reverse proxy (nginx, Traefik, Cloudflared), apply
+        werkzeug.middleware.proxy_fix.ProxyFix to the WSGI app so that
+        request.remote_addr reflects the real client IP, not the proxy's.
+    """
+    @functools.wraps(f)
+    def decorated_function(*args, **kwargs):
+        # Log auth status on first invocation
+        _log_auth_status()
+
+        config = _get_webhook_config()
+        has_secret = config['secret'] is not None
+        has_ips = config['allowed_ips_raw'] is not None
+
+        # === CASE 1: Neither configured - allow all (backward compatible) ===
+        if not has_secret and not has_ips:
+            return f(*args, **kwargs)
+
+        # Gather request context for auth checks
+        # SECURITY: Read raw body BEFORE request.json to capture bytes for HMAC.
+        # Flask caches the data internally so request.json still works later.
+        raw_body = request.get_data()
+
+        # Get client IP
+        # NOTE: If behind a reverse proxy, ensure ProxyFix middleware is applied
+        # so request.remote_addr returns the real client IP.
+        client_ip = request.remote_addr
+        signature_header = request.headers.get('X-DragonCP-Signature', '')
+
+        ip_allowed = False
+        sig_valid = False
+
+        # Check IP whitelist if configured
+        if has_ips:
+            allowed_networks = _parse_allowed_ips(config['allowed_ips_raw'])
+            ip_allowed = is_ip_allowed(client_ip, allowed_networks)
+
+        # Check signature if configured
+        if has_secret:
+            sig_valid = verify_webhook_signature(raw_body, signature_header, config['secret'])
+
+        # === CASE 2: IP only - whitelist check ===
+        if has_ips and not has_secret:
+            if ip_allowed:
+                return f(*args, **kwargs)
+            else:
+                logger.warning(
+                    "WEBHOOK_AUTH: Request from unauthorized IP %s rejected "
+                    "(not in WEBHOOK_ALLOWED_IPS whitelist). Endpoint: %s",
+                    client_ip, request.path
+                )
+                return jsonify({
+                    "status": "error",
+                    "message": "Unauthorized: source IP not in whitelist",
+                    "code": "WEBHOOK_IP_REJECTED"
+                }), 403
+
+        # === CASE 3: Secret only - signature check ===
+        if has_secret and not has_ips:
+            if sig_valid:
+                return f(*args, **kwargs)
+            else:
+                if not signature_header:
+                    logger.warning(
+                        "WEBHOOK_AUTH: Missing X-DragonCP-Signature header from %s. "
+                        "Endpoint: %s",
+                        client_ip, request.path
+                    )
+                    return jsonify({
+                        "status": "error",
+                        "message": "Unauthorized: missing X-DragonCP-Signature header",
+                        "code": "WEBHOOK_SIGNATURE_MISSING"
+                    }), 401
+                else:
+                    logger.warning(
+                        "WEBHOOK_AUTH: Invalid signature from %s. Endpoint: %s",
+                        client_ip, request.path
+                    )
+                    return jsonify({
+                        "status": "error",
+                        "message": "Unauthorized: invalid webhook signature",
+                        "code": "WEBHOOK_SIGNATURE_INVALID"
+                    }), 401
+
+        # === CASE 4: Both configured - either passes (OR logic) ===
+        if has_secret and has_ips:
+            if ip_allowed or sig_valid:
+                if ip_allowed:
+                    logger.debug(
+                        "WEBHOOK_AUTH: Request from whitelisted IP %s allowed. "
+                        "Endpoint: %s",
+                        client_ip, request.path
+                    )
+                else:
+                    logger.debug(
+                        "WEBHOOK_AUTH: Valid signature from %s allowed. "
+                        "Endpoint: %s",
+                        client_ip, request.path
+                    )
+                return f(*args, **kwargs)
+            else:
+                logger.warning(
+                    "WEBHOOK_AUTH: Request from %s rejected - IP not whitelisted "
+                    "AND signature %s. Endpoint: %s",
+                    client_ip,
+                    "missing" if not signature_header else "invalid",
+                    request.path
+                )
+                return jsonify({
+                    "status": "error",
+                    "message": "Unauthorized: IP not whitelisted and signature verification failed",
+                    "code": "WEBHOOK_AUTH_FAILED"
+                }), 403
+
+        # Fallback (should not reach here, but safety net)
+        return f(*args, **kwargs)
+
+    return decorated_function
+
+
+def reload_webhook_config():
+    """
+    Force reload of webhook configuration from env file.
+
+    Call this after updating dragoncp_env.env to pick up changes
+    without restarting the application.
+    """
+    global _webhook_config_cache, _auth_status_logged
+    _webhook_config_cache = None
+    _auth_status_logged = False
+    logger.info("WEBHOOK_AUTH: Configuration reloaded")


### PR DESCRIPTION
## Summary

- **Webhook authentication** for the three unauthenticated POST receivers (`/api/webhook/movies`, `/api/webhook/series`, `/api/webhook/anime`) via HMAC-SHA256 signature verification (`X-DragonCP-Signature` header) and source IP whitelisting with CIDR support
- **Application-wide path traversal protection** across all file operations — routes, services, backup restore, rename — ensuring no external input can escape configured media/backup directories
- **Backward compatible**: if neither `WEBHOOK_SECRET` nor `WEBHOOK_ALLOWED_IPS` is configured, webhooks continue to work as before (with a warning log)

## What changed

### New files
| File | Purpose |
|---|---|
| `security.py` | Centralized path validation: `validate_path_component()`, `validate_relative_path()`, `assert_path_within_bounds()`. Includes a prominent docstring so future changes stay within bounds |
| `webhook_auth.py` | `@require_webhook_auth` decorator. Supports 4 modes: no config (allow all), IP only, signature only, both (either passes) |

### Modified files
| File | Change |
|---|---|
| `routes/webhooks.py` | Applied `@require_webhook_auth` to the 3 receiver endpoints |
| `routes/media.py` | Path component validation on 5 endpoints + realpath bounds check on assembled dest_path |
| `routes/transfers.py` | Path component validation + realpath bounds check before transfer |
| `routes/backups.py` | Relative path validation on restore file list; reject empty selection |
| `services/path_service.py` | Bounds checking in `get_destination_path()`, `construct_destination_from_components()`, `validate_destination_path()` (fail-closed) |
| `services/rename_service.py` | Bounds checking in `_map_to_local_path()`; `PathTraversalError` handling in both rename execution and verification |
| `services/backup_service.py` | Validate backup/dest paths against configured boundaries; fail-closed when boundaries missing |
| `config.py` | Added `get_all_allowed_paths()` and `get_destination_paths()` helpers |
| `dragoncp_env_sample.env` | Added `WEBHOOK_SECRET` and `WEBHOOK_ALLOWED_IPS` config entries |

### Security design decisions
- **Fail-closed everywhere**: missing config = reject (except webhook auth backward compat)
- **Defence-in-depth**: component validation at route level + realpath bounds check at route level + service-level bounds check
- Non-string JSON values (int, list, dict) in path fields return clean 400 instead of crashing
- `files=[]` on backup restore is explicitly rejected (not silently treated as "restore all")
- Webhook auth fallback branch returns 500 instead of allowing through

## Test plan
- [x] Verify existing tests pass (`pytest tests/`)
- [ ] Send webhook POST without config — should pass with warning log
- [ ] Set `WEBHOOK_ALLOWED_IPS` — verify whitelisted IP passes, other IP gets 403
- [ ] Set `WEBHOOK_SECRET` — verify valid `X-DragonCP-Signature: sha256=...` passes, missing/bad sig gets 401
- [ ] Request `/api/seasons/tvshows/../../etc/passwd` — should get 400
- [ ] POST `/api/transfer` with `folder_name: "../../etc"` — should get 400
- [ ] POST backup restore with `files: ["../../etc/passwd"]` — should get 400
- [ ] POST backup restore with `files: []` — should get 400
- [ ] Normal media browsing, transfers, renames, restores still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook authentication using HMAC signatures and optional IP allowlisting on webhook receivers.
  * Added config helpers to enumerate allowed security-boundary and destination paths.
* **Security Enhancements**
  * Implemented centralized path component and resolved-path boundary validation across backups, transfers, media browsing, and renames.
  * Webhook and transfer/restore endpoints now fail fast on invalid inputs; restore rejects explicitly provided empty file lists.
  * Improved SSH security with configurable host-key verification and safer remote command path quoting.
* **Documentation**
  * Expanded environment examples for webhook and SSH host-key verification.
  * Added attribution policy note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->