### PR TITLE
Fix the Backups page on a phone

### DIFF
--- a/frontend/src/components/backups/delete-dialog.tsx
+++ b/frontend/src/components/backups/delete-dialog.tsx
@@ -130,7 +130,16 @@ export function SelectionBar({
 }) {
   if (count === 0) return null;
   return (
-    <div className="sticky bottom-0 z-20 flex flex-wrap items-center gap-2 border-t border-border bg-card/95 px-4 py-2.5 backdrop-blur-md">
+    /*
+     * Docked to the viewport on a phone, sticky within its card from `lg` up.
+     *
+     * `sticky bottom-0` only pins against a scrolling ancestor. On mobile the
+     * card flows with the page instead of being height-constrained, so the bar
+     * sat at the very bottom of a long list — you could tick five items and the
+     * action to do anything with them was a screen and a half away. Fixed above
+     * the bottom navigation puts it where the selection is made.
+     */
+    <div className="fixed inset-x-0 bottom-[calc(3.75rem+env(safe-area-inset-bottom))] z-40 flex flex-wrap items-center gap-2 border-y border-border bg-card/95 px-4 py-2.5 backdrop-blur-md lg:sticky lg:inset-x-auto lg:bottom-0 lg:z-20 lg:border-y-0 lg:border-t">
       <span className="text-[12.5px] font-medium">{count} selected</span>
       <div className="ml-auto flex items-center gap-2">
         <Button variant="ghost" size="sm" onClick={onClear}>

--- a/frontend/src/components/pages/backups.tsx
+++ b/frontend/src/components/pages/backups.tsx
@@ -285,7 +285,17 @@ export function BackupsPage() {
    * it jumped straight from the toolbar to the unidentified section.
    */
   return (
-    <div className="flex flex-col gap-4 p-4 lg:min-h-0 lg:flex-1">
+    <div
+      className={cn(
+        "flex flex-col gap-4 p-4 lg:min-h-0 lg:flex-1",
+        // Room for the selection bar, which is docked to the viewport on a phone
+        // and so covers whatever the page happens to end with — the unidentified
+        // list, or the versions card when there is no unidentified section.
+        // Reserved here rather than inside a list, because the bar floats over
+        // the page rather than over any one of them.
+        selectionCount > 0 && "pb-20 lg:pb-4"
+      )}
+    >
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h1 className="font-display text-xl font-semibold">Backups</h1>
@@ -478,7 +488,10 @@ export function BackupsPage() {
             className="flex flex-col lg:min-h-0"
             contentClassName="flex flex-col lg:min-h-0 lg:flex-1"
           >
-            <ScrollArea className="max-h-[55vh] lg:h-full lg:max-h-[70vh]">
+            {/* Shrinks rather than filling, so the selection bar below it has
+                somewhere to go. `h-full` took the whole content box and the
+                sticky bar was pulled back up over the last row of the list. */}
+            <ScrollArea className="max-h-[55vh] lg:max-h-[70vh] lg:min-h-0 lg:flex-1">
               {slots.isLoading ? (
                 <div className="space-y-2 p-3">
                   {[0, 1, 2, 3, 4].map((row) => (

--- a/frontend/src/components/pages/backups.tsx
+++ b/frontend/src/components/pages/backups.tsx
@@ -274,8 +274,18 @@ export function BackupsPage() {
 
   const notConfigured = overview.data && !overview.data.configured;
 
+  /*
+   * The page fills the viewport and scrolls INSIDE its panes only from `lg` up.
+   *
+   * Below that it is an ordinary flowing column that the app shell scrolls.
+   * `flex-1` is `flex: 1 1 0%` — it takes leftover space and nothing else — and
+   * on a phone the header, tiles, disk bar and toolbar leave none, so the pane
+   * container collapsed to zero and the titles and versions lists rendered at
+   * 0px. They were in the DOM the whole time, which is why the page looked like
+   * it jumped straight from the toolbar to the unidentified section.
+   */
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
+    <div className="flex flex-col gap-4 p-4 lg:min-h-0 lg:flex-1">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <h1 className="font-display text-xl font-semibold">Backups</h1>
@@ -337,7 +347,10 @@ export function BackupsPage() {
           ))}
         </div>
 
-        <div className="relative min-w-0 flex-1 sm:max-w-xs">
+        {/* A floor, not just `min-w-0`: on a phone the back control joins this
+            row and the field was squeezed down to its own magnifier icon.
+            Below the floor the row wraps instead. */}
+        <div className="relative min-w-[9rem] flex-1 sm:max-w-xs">
           <IconSearch className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             value={search}
@@ -384,14 +397,17 @@ export function BackupsPage() {
         )}
       </div>
 
-      <div className={cn("grid min-h-0 flex-1 gap-4", isWide && "lg:grid-cols-[290px_1fr]")}>
+      <div className={cn("grid gap-4 lg:min-h-0 lg:flex-1", isWide && "lg:grid-cols-[290px_1fr]")}>
         {(isWide || pane === "titles") && (
           <SectionCard
             label="Titles"
-            className="flex min-h-0 flex-col"
-            contentClassName="min-h-0 flex-1"
+            className="flex flex-col lg:min-h-0"
+            contentClassName="lg:min-h-0 lg:flex-1"
           >
-            <ScrollArea className="h-full max-h-[60vh] lg:max-h-[70vh]">
+            {/* A definite height below `lg`: the viewport inside is `size-full`,
+                so a percentage height of an auto-height parent gives it nothing
+                to scroll within. */}
+            <ScrollArea className="max-h-[55vh] lg:h-full lg:max-h-[70vh]">
               {titles.isLoading ? (
                 <div className="space-y-2 p-3">
                   {[0, 1, 2, 3].map((row) => (
@@ -459,10 +475,10 @@ export function BackupsPage() {
             description={
               slots.data ? `${slots.data.total} item(s) with stored versions` : undefined
             }
-            className="flex min-h-0 flex-col"
-            contentClassName="min-h-0 flex-1"
+            className="flex flex-col lg:min-h-0"
+            contentClassName="flex flex-col lg:min-h-0 lg:flex-1"
           >
-            <ScrollArea className="h-full max-h-[70vh]">
+            <ScrollArea className="max-h-[55vh] lg:h-full lg:max-h-[70vh]">
               {slots.isLoading ? (
                 <div className="space-y-2 p-3">
                   {[0, 1, 2, 3, 4].map((row) => (
@@ -533,8 +549,19 @@ export function BackupsPage() {
       )}
 
       <Sheet open={Boolean(slotKey)} onOpenChange={(open) => !open && setSlotKey(null)}>
-        <SheetContent side="right" className="w-full gap-0 p-0 sm:max-w-xl">
-          <SheetTitle className="border-b border-border px-4 py-3 text-[13.5px]">
+        {/*
+          The width classes carry the same `data-[side=right]:` prefix the sheet's
+          own defaults use. Without it a plain `w-full` never applies: the base
+          sets `data-[side=right]:w-3/4`, which is the more specific selector AND
+          a different key to tailwind-merge, so the caller's width was dropped and
+          the inspector opened at three-quarter width with the page showing behind
+          it. Matching the prefix lets the merge see one width and keep this one.
+        */}
+        <SheetContent
+          side="right"
+          className="gap-0 p-0 data-[side=right]:w-full data-[side=right]:sm:max-w-xl"
+        >
+          <SheetTitle className="border-b border-border py-3 pr-12 pl-4 text-[13.5px]">
             {slot.data?.display || "Versions"}
           </SheetTitle>
           <div className="min-h-0 flex-1 overflow-y-auto">


### PR DESCRIPTION
The Backups page was unusable on a phone: the titles and versions lists did not
appear at all. Desktop was unaffected, which is why it survived the rework.

Verified in a real browser at 390px, and re-checked at 768px and 1440px.

## The lists rendered at 0px

They were in the DOM the whole time, at zero height:

| Element | Height at 390px |
|---|---|
| pane container `grid min-h-0 flex-1` | **0** |
| SectionCard | 2 |
| ScrollArea `h-full max-h-[60vh]` | **0** |

`flex-1` is `flex: 1 1 0%` — it takes *leftover* space and nothing else. On a
phone the header, stat tiles, disk bar and toolbar consume all of it, so the
panes got none, and `h-full` of a zero-height parent is zero. On a desktop there
is spare height, so the same markup worked.

The page is now only a viewport-filling layout from `lg` up; below that it is an
ordinary column that the app shell scrolls. The panes use `max-h-[55vh]`, so they
size to their content and cap with internal scrolling once the list is long.

## Three more, found by walking the page

- **The search box collapsed to its own magnifier icon** once the "← Titles"
  control joined its row — `min-w-0` let it shrink to nothing. It has a floor
  now, so the row wraps instead.
- **The version inspector opened at three-quarter width**, with the page showing
  behind it. The sheet sets `data-[side=right]:w-3/4`, which is both a more
  specific selector than a caller's `w-full` and a different key to
  tailwind-merge, so the width passed in was silently dropped. Matching the
  variant prefix lets the merge see one width and keep this one. The title also
  gained right padding so it stops running under the close button.
- **The selection bar sat below the fold.** `sticky bottom-0` needs a constrained
  scrolling ancestor, and the card now flows on mobile — so ticking items put the
  action for them a screen and a half further down. It is docked above the bottom
  navigation instead.

## Not changed

The same sheet-width problem affects the mobile sidebar and Explore's inspector:
all three call sites have their width overridden by the base class. Fixing it in
`sheet.tsx` so callers win would change how those two look, so this change stays
scoped to Backups. Worth doing centrally as a follow-up.

## Verification

406 tests pass; build, Prettier and ESLint clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the backups page layout across mobile, tablet, and desktop screen sizes.
  * Updated the selection bar to remain accessible above mobile navigation and device safe areas.
  * Improved scrolling behavior and sizing for backup panes, cards, and the version inspector.
  * Refined responsive spacing, borders, and positioning for a more consistent interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->